### PR TITLE
Add HACS metadata and documentation for Calendar Week Card

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,54 @@
-# calendar-week-card
+# Calendar Week Card
+
+A custom Lovelace card that renders a week-based calendar view in Home Assistant. It automatically loads calendar entities, lets you assign persistent colors per calendar, and provides dialogs for reviewing events.
+
+## Features
+
+- Weekly grid layout with current time indicator
+- Automatic calendar discovery with optional manual entity list
+- Persistent color picker for each calendar
+- Event detail dialog with start/end information
+
+## Installation
+
+### HACS (recommended)
+
+1. Ensure you are running Home Assistant 2023.5 or newer.
+2. In HACS, add this repository as a custom repository (type: `Lovelace`).
+3. Install **Calendar Week Card** from the custom repositories list.
+4. Reload your Lovelace resources or restart Home Assistant if prompted.
+
+### Manual installation
+
+1. Copy `calendar-week-card.js` into `<config>/www/community/calendar-week-card/`.
+2. Add the resource to Home Assistant:
+   ```yaml
+   url: /hacsfiles/calendar-week-card/calendar-week-card.js
+   type: module
+   ```
+3. Reload the Lovelace dashboard.
+
+## Lovelace configuration
+
+```yaml
+type: custom:calendar-week-card
+title: Family calendar
+entities:
+  - calendar.family
+  - calendar.work
+colors:
+  calendar.family: "#6BCB77"
+  calendar.work: "#4D96FF"
+```
+
+- `title` (optional): Override the header text.
+- `entities` (optional): Explicit list of calendar entities. When omitted, the card will display all available calendars.
+- `colors` (optional): Map of entity IDs to hex color values. Values can be adjusted from the built-in settings dialog.
+
+## Development
+
+The card is a single JavaScript module. To contribute, edit `calendar-week-card.js` and open a pull request.
+
+## License
+
+This project is released under the MIT License.

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,8 @@
+{
+  "name": "Calendar Week Card",
+  "filename": "calendar-week-card.js",
+  "render_readme": true,
+  "content_in_root": true,
+  "country": "DE",
+  "homeassistant": "2023.5.0"
+}

--- a/info.md
+++ b/info.md
@@ -1,0 +1,13 @@
+# Calendar Week Card
+
+A Lovelace card that displays a weekly calendar grid with automatic entity discovery, configurable colors, and event dialogs.
+
+## Usage
+
+```yaml
+type: custom:calendar-week-card
+entities:
+  - calendar.family
+```
+
+Colors can be customized from the card's settings dialog and are saved locally per browser.


### PR DESCRIPTION
## Summary
- add HACS manifest and info file so the card can be distributed through HACS
- expand the README with installation instructions, configuration example, and contribution notes

## Testing
- not run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f13bf29108328869ccfd299c66554)