### PR TITLE
Add localization and language selection to calendar week card

### DIFF
--- a/calendar-week-card.js
+++ b/calendar-week-card.js
@@ -665,10 +665,11 @@ class CalendarWeekCard extends HTMLElement {
         Object.assign(languageSelect.style, {
             padding: "6px 10px",
             borderRadius: "6px",
-            border: "1px solid #ccc",
+            border: "1px solid var(--divider-color, #ccc)",
             fontSize: "0.95em",
             cursor: "pointer",
-            background: "#fff"
+            background: "var(--card-background-color, #fff)",
+            color: "var(--primary-text-color, #111)"
         });
 
         const systemOption = document.createElement("option");


### PR DESCRIPTION
## Summary
- add translation resources and helpers to localize the calendar week card
- format headers, event times, and dialogs with the selected or system language
- provide a settings dropdown to persist the language preference with a system-default option

## Testing
- not run (not available)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f40d190cc8328be5056f3b92abaaf)