### PR TITLE
Allow YAML config to override dialog settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,41 @@ entities:
 
 - `title` (optional): Override the header text.
 - `entities` (optional): Explicit list of calendar entities. When omitted, all available calendars are shown.
-#### comming soon
-- `colors` (optional): Map of entity IDs to hex color values. Values can also be adjusted from the card's settings dialog.
+
+### configuration options
+
+Every option that is available in the in-card settings dialog can also be controlled from YAML. This makes it easy to keep multiple dashboards consistent or to share a predefined look and feel with other users.
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `title` | string | – | Optional title shown in the header bar. |
+| `entities` | list | auto-discover | Calendars to display. When omitted the card queries Home Assistant for all available calendars. |
+| `colors` | map | generated | Map of `calendar.entity_id` → color. Colors accept hex values or any CSS color string. Values defined here override colors chosen in the dialog. |
+| `hidden_entities` | list | `[]` | Calendars that should start hidden. When provided, this list takes precedence over any per-browser visibility stored from the dialog. |
+| `language` | string | `system` | Locale used for all labels. Use `system` or one of the supported language codes (see `src/localization.js`). |
+| `theme` | string | `system` | Force the light or dark theme (`light`, `dark`, or `system`). YAML values override the per-browser theme preference. |
+| `trim_unused_hours` | boolean | `false` | When `true`, collapses empty time slots outside the hours that contain events. |
+| `highlight_today` | boolean | `true` | Toggle the highlight around the current day column. |
+| `today_highlight_color` | string | `#4D96FF` | Color used for the “today” highlight. Accepts hex or CSS color strings. YAML value wins over any color picked in the dialog. |
+
+Example with custom options:
+
+```yaml
+type: custom:calendar-week-card
+title: Team Schedule
+language: de
+theme: dark
+trim_unused_hours: true
+highlight_today: true
+today_highlight_color: '#3366ff'
+entities:
+  - calendar.team
+  - calendar.holidays
+colors:
+  calendar.team: '#6bcf7d'
+hidden_entities:
+  - calendar.holidays
+```
 
 ## Development
 

--- a/info.md
+++ b/info.md
@@ -19,3 +19,33 @@ type: custom:calendar-week-card
 ```
 
 Colors and visibility can be adjusted from the in-card settings dialog and are saved per browser profile.
+
+## configuration options
+
+All values that can be changed in the settings dialog can also be defined in YAML. This allows you to ship a card configuration with predefined colors, visibility, and behavior:
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `title` | string | – | Optional title shown above the navigation controls. |
+| `entities` | list | auto-discover | Calendars to display. Leave empty to auto-detect. |
+| `colors` | map | generated | Map of entity IDs to colors. YAML values override dialog choices. |
+| `hidden_entities` | list | `[]` | Calendars that should start hidden. Overrides stored visibility. |
+| `language` | string | `system` | Language for labels (`system` or a supported language code). |
+| `theme` | string | `system` | Force `light`, `dark`, or `system` theme. |
+| `trim_unused_hours` | boolean | `false` | Collapse empty time ranges when `true`. |
+| `highlight_today` | boolean | `true` | Enable or disable the today highlight. |
+| `today_highlight_color` | string | `#4D96FF` | Override the color of the today highlight. |
+
+Example:
+
+```yaml
+type: custom:calendar-week-card
+language: fr
+theme: light
+trim_unused_hours: true
+today_highlight_color: '#3a7bff'
+hidden_entities:
+  - calendar.travel
+colors:
+  calendar.family: '#ff9f1c'
+```

--- a/src/calendar-week-card.js
+++ b/src/calendar-week-card.js
@@ -99,6 +99,7 @@ export class CalendarWeekCard extends HTMLElement {
         this._systemThemeListener = null;
         this.baseColors = {};
         this.baseHiddenEntities = [];
+        this._configOverrides = {};
     }
     resolveLanguage(preference) {
         return resolveLanguage(preference, {
@@ -184,8 +185,16 @@ export class CalendarWeekCard extends HTMLElement {
         } catch (err) {
             storedThemePreference = null;
         }
+        const hasThemeOverride = this._configOverrides?.theme === true;
         const configTheme = typeof this.config?.theme === "string" ? this.config.theme : null;
-        const initialThemePreference = storedThemePreference || configTheme || "system";
+        let initialThemePreference = "system";
+        if (hasThemeOverride && configTheme) {
+            initialThemePreference = configTheme;
+        } else if (storedThemePreference) {
+            initialThemePreference = storedThemePreference;
+        } else if (configTheme) {
+            initialThemePreference = configTheme;
+        }
         const validThemes = ["light", "dark", "system"];
         this.themePreference = validThemes.includes(initialThemePreference) ? initialThemePreference : "system";
         this.config.theme = this.themePreference;
@@ -366,12 +375,34 @@ export class CalendarWeekCard extends HTMLElement {
     }
 
     setConfig(config) {
-        this.config = structuredClone(config) || {};
-        this.config.colors = this.config.colors || {};
+        const rawConfig = config || {};
+        const hasOwn = (key) => Object.prototype.hasOwnProperty.call(rawConfig, key);
+        this._configOverrides = {
+            colors: hasOwn("colors"),
+            hidden_entities: hasOwn("hidden_entities"),
+            language: hasOwn("language"),
+            theme: hasOwn("theme"),
+            highlight_today: hasOwn("highlight_today"),
+            today_highlight_color: hasOwn("today_highlight_color"),
+            trim_unused_hours: hasOwn("trim_unused_hours")
+        };
+
+        this.config = structuredClone(rawConfig) || {};
+        this.config.colors = this.config.colors && typeof this.config.colors === "object" ? this.config.colors : {};
         this.config.hidden_entities = Array.isArray(this.config.hidden_entities) ? this.config.hidden_entities : [];
-        const storedLanguagePreference = localStorage.getItem("calendar-week-card-language");
+
+        let storedLanguagePreference = null;
+        try {
+            storedLanguagePreference = localStorage.getItem("calendar-week-card-language");
+        } catch (err) {
+            storedLanguagePreference = null;
+        }
         const configLanguage = typeof this.config.language === "string" ? this.config.language : null;
-        this.languagePreference = configLanguage || storedLanguagePreference || "system";
+        const hasLanguageOverride = this._configOverrides.language && configLanguage;
+        const languagePreferenceCandidate = hasLanguageOverride
+            ? configLanguage
+            : (configLanguage || storedLanguagePreference || "system");
+        this.languagePreference = languagePreferenceCandidate || "system";
         if (this.languagePreference !== "system") {
             const normalized = normalizeLanguage(this.languagePreference);
             this.languagePreference = SUPPORTED_LANGUAGES.includes(normalized) ? normalized : "system";
@@ -387,13 +418,25 @@ export class CalendarWeekCard extends HTMLElement {
         this.initializeThemePreference();
 
         // Load saved colors
-        const savedColors = localStorage.getItem("calendar-week-card-colors");
+        let savedColors = null;
+        try {
+            savedColors = localStorage.getItem("calendar-week-card-colors");
+        } catch (err) {
+            savedColors = null;
+        }
         if (savedColors) {
-            this.config.colors = { ...this.config.colors, ...JSON.parse(savedColors) };
+            try {
+                const parsedColors = JSON.parse(savedColors);
+                if (parsedColors && typeof parsedColors === "object") {
+                    this.config.colors = { ...parsedColors, ...this.config.colors };
+                }
+            } catch (err) {
+                console.warn("calendar-week-card: Failed to parse saved colors", err);
+            }
         }
 
         const savedHidden = localStorage.getItem(this.configHiddenKey);
-        if (savedHidden) {
+        if (savedHidden && !this._configOverrides.hidden_entities) {
             try {
                 const parsedHidden = JSON.parse(savedHidden);
                 if (Array.isArray(parsedHidden)) {
@@ -413,22 +456,58 @@ export class CalendarWeekCard extends HTMLElement {
             this.assignDefaultColors(this.config.entities);
         }
 
-        const savedHighlightColor = localStorage.getItem("calendar-week-card-today-highlight-color");
-        if (savedHighlightColor) {
-            this.config.today_highlight_color = savedHighlightColor;
-        } else if (!this.config.today_highlight_color) {
+        let savedHighlightColor = null;
+        try {
+            savedHighlightColor = localStorage.getItem("calendar-week-card-today-highlight-color");
+        } catch (err) {
+            savedHighlightColor = null;
+        }
+        const hasHighlightColorOverride = this._configOverrides.today_highlight_color;
+        if (hasHighlightColorOverride && typeof this.config.today_highlight_color === "string") {
+            this.config.today_highlight_color = getHexColor(this.config.today_highlight_color, "#4D96FF");
+        } else if (savedHighlightColor) {
+            this.config.today_highlight_color = getHexColor(savedHighlightColor, this.config.today_highlight_color || "#4D96FF");
+        } else if (typeof this.config.today_highlight_color === "string") {
+            this.config.today_highlight_color = getHexColor(this.config.today_highlight_color, "#4D96FF");
+        } else {
             this.config.today_highlight_color = "#4D96FF";
         }
 
-        const savedHighlightEnabled = localStorage.getItem("calendar-week-card-highlight-enabled");
-        if (savedHighlightEnabled !== null) {
+        let savedHighlightEnabled = null;
+        try {
+            savedHighlightEnabled = localStorage.getItem("calendar-week-card-highlight-enabled");
+        } catch (err) {
+            savedHighlightEnabled = null;
+        }
+        const hasHighlightOverride = this._configOverrides.highlight_today;
+        if (hasHighlightOverride) {
+            if (typeof this.config.highlight_today === "string") {
+                this.config.highlight_today = this.config.highlight_today !== "false";
+            } else {
+                this.config.highlight_today = this.config.highlight_today !== false;
+            }
+        } else if (savedHighlightEnabled !== null) {
             this.config.highlight_today = savedHighlightEnabled !== "false";
+        } else if (typeof this.config.highlight_today === "string") {
+            this.config.highlight_today = this.config.highlight_today !== "false";
         } else if (typeof this.config.highlight_today !== "boolean") {
             this.config.highlight_today = true;
         }
 
-        const savedTrimUnused = localStorage.getItem(this.trimUnusedHoursKey);
-        if (savedTrimUnused !== null) {
+        let savedTrimUnused = null;
+        try {
+            savedTrimUnused = localStorage.getItem(this.trimUnusedHoursKey);
+        } catch (err) {
+            savedTrimUnused = null;
+        }
+        const hasTrimOverride = this._configOverrides.trim_unused_hours;
+        if (hasTrimOverride) {
+            if (typeof this.config.trim_unused_hours === "string") {
+                this.config.trim_unused_hours = this.config.trim_unused_hours !== "false";
+            } else {
+                this.config.trim_unused_hours = this.config.trim_unused_hours === true;
+            }
+        } else if (savedTrimUnused !== null) {
             this.config.trim_unused_hours = savedTrimUnused !== "false";
         } else if (typeof this.config.trim_unused_hours === "string") {
             this.config.trim_unused_hours = this.config.trim_unused_hours !== "false";


### PR DESCRIPTION
## Summary
- ensure YAML-provided values take precedence over browser-stored dialog preferences for theme, highlight, trim, colors, and visibility
- record which options are supplied so the card honours explicit YAML overrides while still allowing per-browser persistence when omitted
- document all configuration keys available from YAML to mirror the settings dialog

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691259b14e0c832888d3c594c38266f2)