### PR TITLE
Add onboarding dialog for missing calendars

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,17 @@
 
 A fully customizable Lovelace card that displays your week at a glance in a clean, structured grid. It automatically finds all calendars available in Home Assistant, but you can also choose specific ones if you prefer. Each calendar can have its own color, and you can tweak the entire theme to match your setup.
 
+## Register calendars in Home Assistant
+
+The card can only display entities that Home Assistant already knows about. If the calendar picker in the settings dialog looks empty, first make sure at least one calendar is configured in Home Assistant:
+
+1. Open **Settings → Devices & Services → Integrations** in Home Assistant.
+2. Click **Add Integration** and search for a calendar source such as **Local Calendar**, **Google Calendar**, or another provider you use.
+3. Follow the on-screen prompts for the chosen integration and complete the authentication/authorization flow.
+4. When the integration finishes, confirm that a `calendar.*` entity appears under **Settings → Devices & Services → Entities**. That entity will now be auto-discovered by the Calendar Week Card (or you can list it manually via the `entities` option).
+
+Once at least one calendar entity exists, the card can discover it automatically or you can explicitly list the entities you want to show.
+
 ## Features
 - Weekly grid layout with current time indicator
 - Automatic calendar discovery with optional manual entity list

--- a/calendar-week-card.js
+++ b/calendar-week-card.js
@@ -32,7 +32,17 @@ const TRANSLATIONS = {
         resetDataDescription: "Remove saved colors, language, highlight, and theme preferences.",
         resetConfirmation: "Clear stored calendar settings? This cannot be undone.",
         trimUnusedHours: "Trim blank hours",
-        trimUnusedHoursDescription: "Hide early and late hours without events."
+        trimUnusedHoursDescription: "Hide early and late hours without events.",
+        noCalendarsTitle: "No calendars found",
+        noCalendarsDescription: "Home Assistant has not registered any calendar entities yet, so the card has nothing to display.",
+        noCalendarsStepsIntro: "To fix this, please:",
+        noCalendarsStepIntegrations: "Open Settings → Devices & Services → Integrations.",
+        noCalendarsStepAdd: "Add a calendar integration such as Local Calendar, Google Calendar, CalDAV, or any other provider you use.",
+        noCalendarsStepVerify: "Wait until at least one `calendar.*` entity appears, then return to this dashboard and refresh the card.",
+        noCalendarsLinksTitle: "Need help?",
+        noCalendarsOpenIntegrations: "Open Integrations",
+        noCalendarsReadGuide: "Read setup guide",
+        noCalendarsRefresh: "Check again"
     },
     de: {
         today: "Heute",
@@ -62,7 +72,17 @@ const TRANSLATIONS = {
         resetDataDescription: "Entfernt gespeicherte Farben, Sprache, Hervorhebung und Theme-Einstellungen.",
         resetConfirmation: "Gespeicherte Kalender-Einstellungen wirklich löschen? Dies kann nicht rückgängig gemacht werden.",
         trimUnusedHours: "Unbenutzte Randstunden kürzen",
-        trimUnusedHoursDescription: "Blendet frühe und späte Stunden ohne Termine aus."
+        trimUnusedHoursDescription: "Blendet frühe und späte Stunden ohne Termine aus.",
+        noCalendarsTitle: "Keine Kalender gefunden",
+        noCalendarsDescription: "Home Assistant hat noch keine Kalender-Entitäten registriert, daher kann die Karte nichts anzeigen.",
+        noCalendarsStepsIntro: "So löst du das Problem:",
+        noCalendarsStepIntegrations: "Öffne Einstellungen → Geräte & Dienste → Integrationen.",
+        noCalendarsStepAdd: "Füge eine Kalender-Integration wie Lokaler Kalender, Google Kalender, CalDAV oder einen anderen Anbieter hinzu.",
+        noCalendarsStepVerify: "Warte, bis mindestens eine `calendar.*`-Entität erscheint, und kehre dann zu diesem Dashboard zurück und aktualisiere die Karte.",
+        noCalendarsLinksTitle: "Brauchst du Hilfe?",
+        noCalendarsOpenIntegrations: "Integrationen öffnen",
+        noCalendarsReadGuide: "Setup-Anleitung lesen",
+        noCalendarsRefresh: "Erneut prüfen"
     },
     fr: {
         today: "Aujourd'hui",
@@ -92,7 +112,17 @@ const TRANSLATIONS = {
         resetDataDescription: "Supprime les couleurs, la langue, la mise en évidence et le thème sauvegardés.",
         resetConfirmation: "Effacer les paramètres enregistrés du calendrier ? Cette action est irréversible.",
         trimUnusedHours: "Réduire les heures vides",
-        trimUnusedHoursDescription: "Masque les heures matinales et tardives sans événements."
+        trimUnusedHoursDescription: "Masque les heures matinales et tardives sans événements.",
+        noCalendarsTitle: "Aucun calendrier trouvé",
+        noCalendarsDescription: "Home Assistant n'a pas encore enregistré d'entités de calendrier, la carte ne peut donc rien afficher.",
+        noCalendarsStepsIntro: "Pour résoudre le problème :",
+        noCalendarsStepIntegrations: "Ouvrez Paramètres → Appareils et services → Intégrations.",
+        noCalendarsStepAdd: "Ajoutez une intégration de calendrier telle que Calendrier local, Google Calendar, CalDAV ou tout autre fournisseur utilisé.",
+        noCalendarsStepVerify: "Attendez qu'au moins une entité `calendar.*` apparaisse, puis revenez sur ce tableau de bord et actualisez la carte.",
+        noCalendarsLinksTitle: "Besoin d'aide ?",
+        noCalendarsOpenIntegrations: "Ouvrir les intégrations",
+        noCalendarsReadGuide: "Lire le guide d'installation",
+        noCalendarsRefresh: "Vérifier à nouveau"
     },
     es: {
         today: "Hoy",
@@ -122,7 +152,17 @@ const TRANSLATIONS = {
         resetDataDescription: "Elimina los colores, el idioma, el resaltado y el tema guardados.",
         resetConfirmation: "¿Borrar la configuración guardada del calendario? Esta acción no se puede deshacer.",
         trimUnusedHours: "Recortar horas vacías",
-        trimUnusedHoursDescription: "Oculta las horas tempranas y tardías sin eventos."
+        trimUnusedHoursDescription: "Oculta las horas tempranas y tardías sin eventos.",
+        noCalendarsTitle: "No se encontraron calendarios",
+        noCalendarsDescription: "Home Assistant todavía no ha registrado entidades de calendario, por lo que la tarjeta no puede mostrar nada.",
+        noCalendarsStepsIntro: "Para solucionarlo:",
+        noCalendarsStepIntegrations: "Abre Ajustes → Dispositivos y servicios → Integraciones.",
+        noCalendarsStepAdd: "Añade una integración de calendario como Calendario local, Google Calendar, CalDAV u otro proveedor que utilices.",
+        noCalendarsStepVerify: "Espera a que aparezca al menos una entidad `calendar.*`, luego regresa a este panel y actualiza la tarjeta.",
+        noCalendarsLinksTitle: "¿Necesitas ayuda?",
+        noCalendarsOpenIntegrations: "Abrir Integraciones",
+        noCalendarsReadGuide: "Leer guía de configuración",
+        noCalendarsRefresh: "Volver a comprobar"
     },
     it: {
         today: "Oggi",
@@ -152,7 +192,17 @@ const TRANSLATIONS = {
         resetDataDescription: "Rimuove colori, lingua, evidenziazione e tema salvati.",
         resetConfirmation: "Eliminare le impostazioni salvate del calendario? L'operazione è irreversibile.",
         trimUnusedHours: "Riduci ore vuote",
-        trimUnusedHoursDescription: "Nasconde le ore mattutine e serali senza eventi."
+        trimUnusedHoursDescription: "Nasconde le ore mattutine e serali senza eventi.",
+        noCalendarsTitle: "Nessun calendario trovato",
+        noCalendarsDescription: "Home Assistant non ha ancora registrato entità calendario, quindi la scheda non può mostrare nulla.",
+        noCalendarsStepsIntro: "Per risolvere:",
+        noCalendarsStepIntegrations: "Apri Impostazioni → Dispositivi e servizi → Integrazioni.",
+        noCalendarsStepAdd: "Aggiungi un'integrazione calendario come Calendario locale, Google Calendar, CalDAV o un altro provider utilizzato.",
+        noCalendarsStepVerify: "Attendi che compaia almeno un'entità `calendar.*`, poi torna a questa dashboard e aggiorna la scheda.",
+        noCalendarsLinksTitle: "Hai bisogno di aiuto?",
+        noCalendarsOpenIntegrations: "Apri Integrazioni",
+        noCalendarsReadGuide: "Leggi la guida di configurazione",
+        noCalendarsRefresh: "Controlla di nuovo"
     },
     nl: {
         today: "Vandaag",
@@ -182,7 +232,17 @@ const TRANSLATIONS = {
         resetDataDescription: "Verwijdert opgeslagen kleuren, taal, markering en thema-instellingen.",
         resetConfirmation: "Opgeslagen kalenderinstellingen wissen? Dit kan niet ongedaan worden gemaakt.",
         trimUnusedHours: "Lege uren inkorten",
-        trimUnusedHoursDescription: "Verbergt vroege en late uren zonder afspraken."
+        trimUnusedHoursDescription: "Verbergt vroege en late uren zonder afspraken.",
+        noCalendarsTitle: "Geen agenda's gevonden",
+        noCalendarsDescription: "Home Assistant heeft nog geen agenda-entiteiten geregistreerd, waardoor de kaart niets kan tonen.",
+        noCalendarsStepsIntro: "Los dit op door het volgende te doen:",
+        noCalendarsStepIntegrations: "Open Instellingen → Apparaten en services → Integraties.",
+        noCalendarsStepAdd: "Voeg een agenda-integratie toe, zoals Lokale agenda, Google Agenda, CalDAV of een andere aanbieder.",
+        noCalendarsStepVerify: "Wacht tot er minstens één `calendar.*`-entiteit verschijnt en keer dan terug naar dit dashboard om de kaart te vernieuwen.",
+        noCalendarsLinksTitle: "Hulp nodig?",
+        noCalendarsOpenIntegrations: "Integraties openen",
+        noCalendarsReadGuide: "Setup-handleiding lezen",
+        noCalendarsRefresh: "Opnieuw controleren"
     }
 };
 
@@ -502,6 +562,7 @@ class CalendarWeekCard extends HTMLElement {
         this.baseColors = {};
         this.baseHiddenEntities = [];
         this._configOverrides = {};
+        this._noCalendarsDialogVisible = false;
     }
     resolveLanguage(preference) {
         return resolveLanguage(preference, {
@@ -819,6 +880,209 @@ class CalendarWeekCard extends HTMLElement {
         }
 
         return button;
+    }
+
+    dismissNoCalendarsDialog() {
+        if (typeof document === "undefined") {
+            this._noCalendarsDialogVisible = false;
+            return;
+        }
+
+        const existing = document.querySelector("#calendar-week-card-no-calendars");
+        if (existing) {
+            existing.remove();
+        }
+        this._noCalendarsDialogVisible = false;
+    }
+
+    showNoCalendarsDialog() {
+        const hasConfiguredEntities = Array.isArray(this.config?.entities) && this.config.entities.length > 0;
+        const hasAvailableCalendars = Array.isArray(this.availableCalendars) && this.availableCalendars.length > 0;
+
+        if (typeof document === "undefined" || hasConfiguredEntities || hasAvailableCalendars || this._noCalendarsDialogVisible) {
+            return;
+        }
+
+        const palette = this.getDialogPalette();
+        const dialogId = "calendar-week-card-no-calendars";
+        const existing = document.querySelector(`#${dialogId}`);
+        if (existing) {
+            existing.remove();
+        }
+
+        const overlay = document.createElement("div");
+        overlay.id = dialogId;
+        Object.assign(overlay.style, {
+            position: "fixed",
+            top: 0,
+            left: 0,
+            width: "100%",
+            height: "100%",
+            background: palette.overlay,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            padding: "16px",
+            zIndex: 10000,
+            fontFamily: "sans-serif"
+        });
+
+        const closeDialog = () => {
+            overlay.remove();
+            this._noCalendarsDialogVisible = false;
+        };
+
+        overlay.addEventListener("click", event => {
+            if (event.target === overlay) {
+                closeDialog();
+            }
+        });
+
+        const content = document.createElement("div");
+        Object.assign(content.style, {
+            background: palette.background,
+            color: palette.text,
+            borderRadius: "16px",
+            padding: "24px",
+            maxWidth: "520px",
+            width: "100%",
+            boxShadow: "0 12px 30px rgba(0,0,0,0.35)",
+            display: "flex",
+            flexDirection: "column",
+            gap: "12px",
+            border: `1px solid ${palette.border}`
+        });
+        content.addEventListener("click", event => event.stopPropagation());
+
+        const title = document.createElement("h2");
+        title.textContent = this.t("noCalendarsTitle");
+        Object.assign(title.style, {
+            margin: 0,
+            fontSize: "1.35em",
+            fontWeight: 700
+        });
+
+        const description = document.createElement("p");
+        description.textContent = this.t("noCalendarsDescription");
+        Object.assign(description.style, {
+            margin: 0,
+            color: palette.muted,
+            lineHeight: 1.5
+        });
+
+        const stepsIntro = document.createElement("p");
+        stepsIntro.textContent = this.t("noCalendarsStepsIntro");
+        Object.assign(stepsIntro.style, {
+            margin: 0,
+            fontWeight: 600
+        });
+
+        const stepsList = document.createElement("ol");
+        Object.assign(stepsList.style, {
+            margin: 0,
+            paddingLeft: "20px",
+            color: palette.text,
+            lineHeight: 1.5
+        });
+
+        [
+            this.t("noCalendarsStepIntegrations"),
+            this.t("noCalendarsStepAdd"),
+            this.t("noCalendarsStepVerify")
+        ].forEach(text => {
+            const item = document.createElement("li");
+            item.textContent = text;
+            stepsList.appendChild(item);
+        });
+
+        const linksHeading = document.createElement("h3");
+        linksHeading.textContent = this.t("noCalendarsLinksTitle");
+        Object.assign(linksHeading.style, {
+            margin: "12px 0 0 0",
+            fontSize: "1em",
+            fontWeight: 600
+        });
+
+        const linksList = document.createElement("ul");
+        Object.assign(linksList.style, {
+            margin: 0,
+            paddingLeft: "20px",
+            color: palette.muted,
+            lineHeight: 1.4
+        });
+
+        const integrationUrl = "https://my.home-assistant.io/redirect/integrations/";
+        const docsUrl = "https://github.com/TheLuXoR/calendar-week-card?tab=readme-ov-file#register-calendars-in-home-assistant";
+
+        const addLink = (label, url) => {
+            const li = document.createElement("li");
+            const link = document.createElement("a");
+            link.textContent = label;
+            link.href = url;
+            link.target = "_blank";
+            link.rel = "noopener noreferrer";
+            link.style.color = this.readCssColor("--accent-color", "#4D96FF");
+            link.style.fontWeight = 600;
+            li.appendChild(link);
+            linksList.appendChild(li);
+        };
+
+        addLink(this.t("noCalendarsOpenIntegrations"), integrationUrl);
+        addLink(this.t("noCalendarsReadGuide"), docsUrl);
+
+        const buttonRow = document.createElement("div");
+        Object.assign(buttonRow.style, {
+            display: "flex",
+            flexWrap: "wrap",
+            gap: "8px",
+            marginTop: "16px"
+        });
+
+        const openIntegrationsButton = this.createDialogButton(this.t("noCalendarsOpenIntegrations"));
+        openIntegrationsButton.addEventListener("click", () => {
+            if (typeof window !== "undefined") {
+                window.open(integrationUrl, "_blank", "noopener,noreferrer");
+            }
+        });
+
+        const guideButton = this.createDialogButton(this.t("noCalendarsReadGuide"));
+        guideButton.addEventListener("click", () => {
+            if (typeof window !== "undefined") {
+                window.open(docsUrl, "_blank", "noopener,noreferrer");
+            }
+        });
+
+        const refreshButton = this.createDialogButton(this.t("noCalendarsRefresh"));
+        refreshButton.addEventListener("click", () => {
+            closeDialog();
+            if (this._hass) {
+                this.ensureEntities(this._hass).then(() => this.loadEvents(this._hass));
+            }
+        });
+
+        const closeButton = this.createDialogButton(this.t("close"));
+        closeButton.addEventListener("click", closeDialog);
+
+        [openIntegrationsButton, guideButton, refreshButton, closeButton].forEach(btn => {
+            btn.style.flex = "1 1 200px";
+        });
+
+        buttonRow.appendChild(openIntegrationsButton);
+        buttonRow.appendChild(guideButton);
+        buttonRow.appendChild(refreshButton);
+        buttonRow.appendChild(closeButton);
+
+        content.appendChild(title);
+        content.appendChild(description);
+        content.appendChild(stepsIntro);
+        content.appendChild(stepsList);
+        content.appendChild(linksHeading);
+        content.appendChild(linksList);
+        content.appendChild(buttonRow);
+
+        overlay.appendChild(content);
+        document.body.appendChild(overlay);
+        this._noCalendarsDialogVisible = true;
     }
 
     clearStoredData() {
@@ -1475,9 +1739,14 @@ class CalendarWeekCard extends HTMLElement {
         const visibleEntities = entities.filter(entity => !this.isEntityHidden(entity));
 
         if (!visibleEntities.length) {
+            if (!entities.length && !this.config?.entities?.length) {
+                this.showNoCalendarsDialog();
+            }
             this.renderList([]);
             return;
         }
+
+        this.dismissNoCalendarsDialog();
 
         const [start, end] = this.getWeekRange();
         let allEvents = [];
@@ -1886,10 +2155,18 @@ class CalendarWeekCard extends HTMLElement {
                 this.availableCalendars = list.filter(cal => cal?.entity_id);
                 this.dynamicEntities = this.availableCalendars.map(cal => cal.entity_id);
                 this.assignDefaultColors(this.dynamicEntities);
+                if (this.dynamicEntities.length) {
+                    this.dismissNoCalendarsDialog();
+                } else if (!this.config?.entities?.length) {
+                    this.showNoCalendarsDialog();
+                }
             } catch (err) {
                 console.error("calendar-week-card: Failed to load calendars", err);
                 this.availableCalendars = [];
                 this.dynamicEntities = [];
+                if (!this.config?.entities?.length) {
+                    this.showNoCalendarsDialog();
+                }
             }
         })();
 

--- a/dist/calendar-week-card.js
+++ b/dist/calendar-week-card.js
@@ -32,7 +32,17 @@ const TRANSLATIONS = {
         resetDataDescription: "Remove saved colors, language, highlight, and theme preferences.",
         resetConfirmation: "Clear stored calendar settings? This cannot be undone.",
         trimUnusedHours: "Trim blank hours",
-        trimUnusedHoursDescription: "Hide early and late hours without events."
+        trimUnusedHoursDescription: "Hide early and late hours without events.",
+        noCalendarsTitle: "No calendars found",
+        noCalendarsDescription: "Home Assistant has not registered any calendar entities yet, so the card has nothing to display.",
+        noCalendarsStepsIntro: "To fix this, please:",
+        noCalendarsStepIntegrations: "Open Settings → Devices & Services → Integrations.",
+        noCalendarsStepAdd: "Add a calendar integration such as Local Calendar, Google Calendar, CalDAV, or any other provider you use.",
+        noCalendarsStepVerify: "Wait until at least one `calendar.*` entity appears, then return to this dashboard and refresh the card.",
+        noCalendarsLinksTitle: "Need help?",
+        noCalendarsOpenIntegrations: "Open Integrations",
+        noCalendarsReadGuide: "Read setup guide",
+        noCalendarsRefresh: "Check again"
     },
     de: {
         today: "Heute",
@@ -62,7 +72,17 @@ const TRANSLATIONS = {
         resetDataDescription: "Entfernt gespeicherte Farben, Sprache, Hervorhebung und Theme-Einstellungen.",
         resetConfirmation: "Gespeicherte Kalender-Einstellungen wirklich löschen? Dies kann nicht rückgängig gemacht werden.",
         trimUnusedHours: "Unbenutzte Randstunden kürzen",
-        trimUnusedHoursDescription: "Blendet frühe und späte Stunden ohne Termine aus."
+        trimUnusedHoursDescription: "Blendet frühe und späte Stunden ohne Termine aus.",
+        noCalendarsTitle: "Keine Kalender gefunden",
+        noCalendarsDescription: "Home Assistant hat noch keine Kalender-Entitäten registriert, daher kann die Karte nichts anzeigen.",
+        noCalendarsStepsIntro: "So löst du das Problem:",
+        noCalendarsStepIntegrations: "Öffne Einstellungen → Geräte & Dienste → Integrationen.",
+        noCalendarsStepAdd: "Füge eine Kalender-Integration wie Lokaler Kalender, Google Kalender, CalDAV oder einen anderen Anbieter hinzu.",
+        noCalendarsStepVerify: "Warte, bis mindestens eine `calendar.*`-Entität erscheint, und kehre dann zu diesem Dashboard zurück und aktualisiere die Karte.",
+        noCalendarsLinksTitle: "Brauchst du Hilfe?",
+        noCalendarsOpenIntegrations: "Integrationen öffnen",
+        noCalendarsReadGuide: "Setup-Anleitung lesen",
+        noCalendarsRefresh: "Erneut prüfen"
     },
     fr: {
         today: "Aujourd'hui",
@@ -92,7 +112,17 @@ const TRANSLATIONS = {
         resetDataDescription: "Supprime les couleurs, la langue, la mise en évidence et le thème sauvegardés.",
         resetConfirmation: "Effacer les paramètres enregistrés du calendrier ? Cette action est irréversible.",
         trimUnusedHours: "Réduire les heures vides",
-        trimUnusedHoursDescription: "Masque les heures matinales et tardives sans événements."
+        trimUnusedHoursDescription: "Masque les heures matinales et tardives sans événements.",
+        noCalendarsTitle: "Aucun calendrier trouvé",
+        noCalendarsDescription: "Home Assistant n'a pas encore enregistré d'entités de calendrier, la carte ne peut donc rien afficher.",
+        noCalendarsStepsIntro: "Pour résoudre le problème :",
+        noCalendarsStepIntegrations: "Ouvrez Paramètres → Appareils et services → Intégrations.",
+        noCalendarsStepAdd: "Ajoutez une intégration de calendrier telle que Calendrier local, Google Calendar, CalDAV ou tout autre fournisseur utilisé.",
+        noCalendarsStepVerify: "Attendez qu'au moins une entité `calendar.*` apparaisse, puis revenez sur ce tableau de bord et actualisez la carte.",
+        noCalendarsLinksTitle: "Besoin d'aide ?",
+        noCalendarsOpenIntegrations: "Ouvrir les intégrations",
+        noCalendarsReadGuide: "Lire le guide d'installation",
+        noCalendarsRefresh: "Vérifier à nouveau"
     },
     es: {
         today: "Hoy",
@@ -122,7 +152,17 @@ const TRANSLATIONS = {
         resetDataDescription: "Elimina los colores, el idioma, el resaltado y el tema guardados.",
         resetConfirmation: "¿Borrar la configuración guardada del calendario? Esta acción no se puede deshacer.",
         trimUnusedHours: "Recortar horas vacías",
-        trimUnusedHoursDescription: "Oculta las horas tempranas y tardías sin eventos."
+        trimUnusedHoursDescription: "Oculta las horas tempranas y tardías sin eventos.",
+        noCalendarsTitle: "No se encontraron calendarios",
+        noCalendarsDescription: "Home Assistant todavía no ha registrado entidades de calendario, por lo que la tarjeta no puede mostrar nada.",
+        noCalendarsStepsIntro: "Para solucionarlo:",
+        noCalendarsStepIntegrations: "Abre Ajustes → Dispositivos y servicios → Integraciones.",
+        noCalendarsStepAdd: "Añade una integración de calendario como Calendario local, Google Calendar, CalDAV u otro proveedor que utilices.",
+        noCalendarsStepVerify: "Espera a que aparezca al menos una entidad `calendar.*`, luego regresa a este panel y actualiza la tarjeta.",
+        noCalendarsLinksTitle: "¿Necesitas ayuda?",
+        noCalendarsOpenIntegrations: "Abrir Integraciones",
+        noCalendarsReadGuide: "Leer guía de configuración",
+        noCalendarsRefresh: "Volver a comprobar"
     },
     it: {
         today: "Oggi",
@@ -152,7 +192,17 @@ const TRANSLATIONS = {
         resetDataDescription: "Rimuove colori, lingua, evidenziazione e tema salvati.",
         resetConfirmation: "Eliminare le impostazioni salvate del calendario? L'operazione è irreversibile.",
         trimUnusedHours: "Riduci ore vuote",
-        trimUnusedHoursDescription: "Nasconde le ore mattutine e serali senza eventi."
+        trimUnusedHoursDescription: "Nasconde le ore mattutine e serali senza eventi.",
+        noCalendarsTitle: "Nessun calendario trovato",
+        noCalendarsDescription: "Home Assistant non ha ancora registrato entità calendario, quindi la scheda non può mostrare nulla.",
+        noCalendarsStepsIntro: "Per risolvere:",
+        noCalendarsStepIntegrations: "Apri Impostazioni → Dispositivi e servizi → Integrazioni.",
+        noCalendarsStepAdd: "Aggiungi un'integrazione calendario come Calendario locale, Google Calendar, CalDAV o un altro provider utilizzato.",
+        noCalendarsStepVerify: "Attendi che compaia almeno un'entità `calendar.*`, poi torna a questa dashboard e aggiorna la scheda.",
+        noCalendarsLinksTitle: "Hai bisogno di aiuto?",
+        noCalendarsOpenIntegrations: "Apri Integrazioni",
+        noCalendarsReadGuide: "Leggi la guida di configurazione",
+        noCalendarsRefresh: "Controlla di nuovo"
     },
     nl: {
         today: "Vandaag",
@@ -182,7 +232,17 @@ const TRANSLATIONS = {
         resetDataDescription: "Verwijdert opgeslagen kleuren, taal, markering en thema-instellingen.",
         resetConfirmation: "Opgeslagen kalenderinstellingen wissen? Dit kan niet ongedaan worden gemaakt.",
         trimUnusedHours: "Lege uren inkorten",
-        trimUnusedHoursDescription: "Verbergt vroege en late uren zonder afspraken."
+        trimUnusedHoursDescription: "Verbergt vroege en late uren zonder afspraken.",
+        noCalendarsTitle: "Geen agenda's gevonden",
+        noCalendarsDescription: "Home Assistant heeft nog geen agenda-entiteiten geregistreerd, waardoor de kaart niets kan tonen.",
+        noCalendarsStepsIntro: "Los dit op door het volgende te doen:",
+        noCalendarsStepIntegrations: "Open Instellingen → Apparaten en services → Integraties.",
+        noCalendarsStepAdd: "Voeg een agenda-integratie toe, zoals Lokale agenda, Google Agenda, CalDAV of een andere aanbieder.",
+        noCalendarsStepVerify: "Wacht tot er minstens één `calendar.*`-entiteit verschijnt en keer dan terug naar dit dashboard om de kaart te vernieuwen.",
+        noCalendarsLinksTitle: "Hulp nodig?",
+        noCalendarsOpenIntegrations: "Integraties openen",
+        noCalendarsReadGuide: "Setup-handleiding lezen",
+        noCalendarsRefresh: "Opnieuw controleren"
     }
 };
 
@@ -502,6 +562,7 @@ class CalendarWeekCard extends HTMLElement {
         this.baseColors = {};
         this.baseHiddenEntities = [];
         this._configOverrides = {};
+        this._noCalendarsDialogVisible = false;
     }
     resolveLanguage(preference) {
         return resolveLanguage(preference, {
@@ -819,6 +880,209 @@ class CalendarWeekCard extends HTMLElement {
         }
 
         return button;
+    }
+
+    dismissNoCalendarsDialog() {
+        if (typeof document === "undefined") {
+            this._noCalendarsDialogVisible = false;
+            return;
+        }
+
+        const existing = document.querySelector("#calendar-week-card-no-calendars");
+        if (existing) {
+            existing.remove();
+        }
+        this._noCalendarsDialogVisible = false;
+    }
+
+    showNoCalendarsDialog() {
+        const hasConfiguredEntities = Array.isArray(this.config?.entities) && this.config.entities.length > 0;
+        const hasAvailableCalendars = Array.isArray(this.availableCalendars) && this.availableCalendars.length > 0;
+
+        if (typeof document === "undefined" || hasConfiguredEntities || hasAvailableCalendars || this._noCalendarsDialogVisible) {
+            return;
+        }
+
+        const palette = this.getDialogPalette();
+        const dialogId = "calendar-week-card-no-calendars";
+        const existing = document.querySelector(`#${dialogId}`);
+        if (existing) {
+            existing.remove();
+        }
+
+        const overlay = document.createElement("div");
+        overlay.id = dialogId;
+        Object.assign(overlay.style, {
+            position: "fixed",
+            top: 0,
+            left: 0,
+            width: "100%",
+            height: "100%",
+            background: palette.overlay,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            padding: "16px",
+            zIndex: 10000,
+            fontFamily: "sans-serif"
+        });
+
+        const closeDialog = () => {
+            overlay.remove();
+            this._noCalendarsDialogVisible = false;
+        };
+
+        overlay.addEventListener("click", event => {
+            if (event.target === overlay) {
+                closeDialog();
+            }
+        });
+
+        const content = document.createElement("div");
+        Object.assign(content.style, {
+            background: palette.background,
+            color: palette.text,
+            borderRadius: "16px",
+            padding: "24px",
+            maxWidth: "520px",
+            width: "100%",
+            boxShadow: "0 12px 30px rgba(0,0,0,0.35)",
+            display: "flex",
+            flexDirection: "column",
+            gap: "12px",
+            border: `1px solid ${palette.border}`
+        });
+        content.addEventListener("click", event => event.stopPropagation());
+
+        const title = document.createElement("h2");
+        title.textContent = this.t("noCalendarsTitle");
+        Object.assign(title.style, {
+            margin: 0,
+            fontSize: "1.35em",
+            fontWeight: 700
+        });
+
+        const description = document.createElement("p");
+        description.textContent = this.t("noCalendarsDescription");
+        Object.assign(description.style, {
+            margin: 0,
+            color: palette.muted,
+            lineHeight: 1.5
+        });
+
+        const stepsIntro = document.createElement("p");
+        stepsIntro.textContent = this.t("noCalendarsStepsIntro");
+        Object.assign(stepsIntro.style, {
+            margin: 0,
+            fontWeight: 600
+        });
+
+        const stepsList = document.createElement("ol");
+        Object.assign(stepsList.style, {
+            margin: 0,
+            paddingLeft: "20px",
+            color: palette.text,
+            lineHeight: 1.5
+        });
+
+        [
+            this.t("noCalendarsStepIntegrations"),
+            this.t("noCalendarsStepAdd"),
+            this.t("noCalendarsStepVerify")
+        ].forEach(text => {
+            const item = document.createElement("li");
+            item.textContent = text;
+            stepsList.appendChild(item);
+        });
+
+        const linksHeading = document.createElement("h3");
+        linksHeading.textContent = this.t("noCalendarsLinksTitle");
+        Object.assign(linksHeading.style, {
+            margin: "12px 0 0 0",
+            fontSize: "1em",
+            fontWeight: 600
+        });
+
+        const linksList = document.createElement("ul");
+        Object.assign(linksList.style, {
+            margin: 0,
+            paddingLeft: "20px",
+            color: palette.muted,
+            lineHeight: 1.4
+        });
+
+        const integrationUrl = "https://my.home-assistant.io/redirect/integrations/";
+        const docsUrl = "https://github.com/TheLuXoR/calendar-week-card?tab=readme-ov-file#register-calendars-in-home-assistant";
+
+        const addLink = (label, url) => {
+            const li = document.createElement("li");
+            const link = document.createElement("a");
+            link.textContent = label;
+            link.href = url;
+            link.target = "_blank";
+            link.rel = "noopener noreferrer";
+            link.style.color = this.readCssColor("--accent-color", "#4D96FF");
+            link.style.fontWeight = 600;
+            li.appendChild(link);
+            linksList.appendChild(li);
+        };
+
+        addLink(this.t("noCalendarsOpenIntegrations"), integrationUrl);
+        addLink(this.t("noCalendarsReadGuide"), docsUrl);
+
+        const buttonRow = document.createElement("div");
+        Object.assign(buttonRow.style, {
+            display: "flex",
+            flexWrap: "wrap",
+            gap: "8px",
+            marginTop: "16px"
+        });
+
+        const openIntegrationsButton = this.createDialogButton(this.t("noCalendarsOpenIntegrations"));
+        openIntegrationsButton.addEventListener("click", () => {
+            if (typeof window !== "undefined") {
+                window.open(integrationUrl, "_blank", "noopener,noreferrer");
+            }
+        });
+
+        const guideButton = this.createDialogButton(this.t("noCalendarsReadGuide"));
+        guideButton.addEventListener("click", () => {
+            if (typeof window !== "undefined") {
+                window.open(docsUrl, "_blank", "noopener,noreferrer");
+            }
+        });
+
+        const refreshButton = this.createDialogButton(this.t("noCalendarsRefresh"));
+        refreshButton.addEventListener("click", () => {
+            closeDialog();
+            if (this._hass) {
+                this.ensureEntities(this._hass).then(() => this.loadEvents(this._hass));
+            }
+        });
+
+        const closeButton = this.createDialogButton(this.t("close"));
+        closeButton.addEventListener("click", closeDialog);
+
+        [openIntegrationsButton, guideButton, refreshButton, closeButton].forEach(btn => {
+            btn.style.flex = "1 1 200px";
+        });
+
+        buttonRow.appendChild(openIntegrationsButton);
+        buttonRow.appendChild(guideButton);
+        buttonRow.appendChild(refreshButton);
+        buttonRow.appendChild(closeButton);
+
+        content.appendChild(title);
+        content.appendChild(description);
+        content.appendChild(stepsIntro);
+        content.appendChild(stepsList);
+        content.appendChild(linksHeading);
+        content.appendChild(linksList);
+        content.appendChild(buttonRow);
+
+        overlay.appendChild(content);
+        document.body.appendChild(overlay);
+        this._noCalendarsDialogVisible = true;
     }
 
     clearStoredData() {
@@ -1475,9 +1739,14 @@ class CalendarWeekCard extends HTMLElement {
         const visibleEntities = entities.filter(entity => !this.isEntityHidden(entity));
 
         if (!visibleEntities.length) {
+            if (!entities.length && !this.config?.entities?.length) {
+                this.showNoCalendarsDialog();
+            }
             this.renderList([]);
             return;
         }
+
+        this.dismissNoCalendarsDialog();
 
         const [start, end] = this.getWeekRange();
         let allEvents = [];
@@ -1886,10 +2155,18 @@ class CalendarWeekCard extends HTMLElement {
                 this.availableCalendars = list.filter(cal => cal?.entity_id);
                 this.dynamicEntities = this.availableCalendars.map(cal => cal.entity_id);
                 this.assignDefaultColors(this.dynamicEntities);
+                if (this.dynamicEntities.length) {
+                    this.dismissNoCalendarsDialog();
+                } else if (!this.config?.entities?.length) {
+                    this.showNoCalendarsDialog();
+                }
             } catch (err) {
                 console.error("calendar-week-card: Failed to load calendars", err);
                 this.availableCalendars = [];
                 this.dynamicEntities = [];
+                if (!this.config?.entities?.length) {
+                    this.showNoCalendarsDialog();
+                }
             }
         })();
 

--- a/src/localization.js
+++ b/src/localization.js
@@ -29,7 +29,17 @@ export const TRANSLATIONS = {
         resetDataDescription: "Remove saved colors, language, highlight, and theme preferences.",
         resetConfirmation: "Clear stored calendar settings? This cannot be undone.",
         trimUnusedHours: "Trim blank hours",
-        trimUnusedHoursDescription: "Hide early and late hours without events."
+        trimUnusedHoursDescription: "Hide early and late hours without events.",
+        noCalendarsTitle: "No calendars found",
+        noCalendarsDescription: "Home Assistant has not registered any calendar entities yet, so the card has nothing to display.",
+        noCalendarsStepsIntro: "To fix this, please:",
+        noCalendarsStepIntegrations: "Open Settings → Devices & Services → Integrations.",
+        noCalendarsStepAdd: "Add a calendar integration such as Local Calendar, Google Calendar, CalDAV, or any other provider you use.",
+        noCalendarsStepVerify: "Wait until at least one `calendar.*` entity appears, then return to this dashboard and refresh the card.",
+        noCalendarsLinksTitle: "Need help?",
+        noCalendarsOpenIntegrations: "Open Integrations",
+        noCalendarsReadGuide: "Read setup guide",
+        noCalendarsRefresh: "Check again"
     },
     de: {
         today: "Heute",
@@ -59,7 +69,17 @@ export const TRANSLATIONS = {
         resetDataDescription: "Entfernt gespeicherte Farben, Sprache, Hervorhebung und Theme-Einstellungen.",
         resetConfirmation: "Gespeicherte Kalender-Einstellungen wirklich löschen? Dies kann nicht rückgängig gemacht werden.",
         trimUnusedHours: "Unbenutzte Randstunden kürzen",
-        trimUnusedHoursDescription: "Blendet frühe und späte Stunden ohne Termine aus."
+        trimUnusedHoursDescription: "Blendet frühe und späte Stunden ohne Termine aus.",
+        noCalendarsTitle: "Keine Kalender gefunden",
+        noCalendarsDescription: "Home Assistant hat noch keine Kalender-Entitäten registriert, daher kann die Karte nichts anzeigen.",
+        noCalendarsStepsIntro: "So löst du das Problem:",
+        noCalendarsStepIntegrations: "Öffne Einstellungen → Geräte & Dienste → Integrationen.",
+        noCalendarsStepAdd: "Füge eine Kalender-Integration wie Lokaler Kalender, Google Kalender, CalDAV oder einen anderen Anbieter hinzu.",
+        noCalendarsStepVerify: "Warte, bis mindestens eine `calendar.*`-Entität erscheint, und kehre dann zu diesem Dashboard zurück und aktualisiere die Karte.",
+        noCalendarsLinksTitle: "Brauchst du Hilfe?",
+        noCalendarsOpenIntegrations: "Integrationen öffnen",
+        noCalendarsReadGuide: "Setup-Anleitung lesen",
+        noCalendarsRefresh: "Erneut prüfen"
     },
     fr: {
         today: "Aujourd'hui",
@@ -89,7 +109,17 @@ export const TRANSLATIONS = {
         resetDataDescription: "Supprime les couleurs, la langue, la mise en évidence et le thème sauvegardés.",
         resetConfirmation: "Effacer les paramètres enregistrés du calendrier ? Cette action est irréversible.",
         trimUnusedHours: "Réduire les heures vides",
-        trimUnusedHoursDescription: "Masque les heures matinales et tardives sans événements."
+        trimUnusedHoursDescription: "Masque les heures matinales et tardives sans événements.",
+        noCalendarsTitle: "Aucun calendrier trouvé",
+        noCalendarsDescription: "Home Assistant n'a pas encore enregistré d'entités de calendrier, la carte ne peut donc rien afficher.",
+        noCalendarsStepsIntro: "Pour résoudre le problème :",
+        noCalendarsStepIntegrations: "Ouvrez Paramètres → Appareils et services → Intégrations.",
+        noCalendarsStepAdd: "Ajoutez une intégration de calendrier telle que Calendrier local, Google Calendar, CalDAV ou tout autre fournisseur utilisé.",
+        noCalendarsStepVerify: "Attendez qu'au moins une entité `calendar.*` apparaisse, puis revenez sur ce tableau de bord et actualisez la carte.",
+        noCalendarsLinksTitle: "Besoin d'aide ?",
+        noCalendarsOpenIntegrations: "Ouvrir les intégrations",
+        noCalendarsReadGuide: "Lire le guide d'installation",
+        noCalendarsRefresh: "Vérifier à nouveau"
     },
     es: {
         today: "Hoy",
@@ -119,7 +149,17 @@ export const TRANSLATIONS = {
         resetDataDescription: "Elimina los colores, el idioma, el resaltado y el tema guardados.",
         resetConfirmation: "¿Borrar la configuración guardada del calendario? Esta acción no se puede deshacer.",
         trimUnusedHours: "Recortar horas vacías",
-        trimUnusedHoursDescription: "Oculta las horas tempranas y tardías sin eventos."
+        trimUnusedHoursDescription: "Oculta las horas tempranas y tardías sin eventos.",
+        noCalendarsTitle: "No se encontraron calendarios",
+        noCalendarsDescription: "Home Assistant todavía no ha registrado entidades de calendario, por lo que la tarjeta no puede mostrar nada.",
+        noCalendarsStepsIntro: "Para solucionarlo:",
+        noCalendarsStepIntegrations: "Abre Ajustes → Dispositivos y servicios → Integraciones.",
+        noCalendarsStepAdd: "Añade una integración de calendario como Calendario local, Google Calendar, CalDAV u otro proveedor que utilices.",
+        noCalendarsStepVerify: "Espera a que aparezca al menos una entidad `calendar.*`, luego regresa a este panel y actualiza la tarjeta.",
+        noCalendarsLinksTitle: "¿Necesitas ayuda?",
+        noCalendarsOpenIntegrations: "Abrir Integraciones",
+        noCalendarsReadGuide: "Leer guía de configuración",
+        noCalendarsRefresh: "Volver a comprobar"
     },
     it: {
         today: "Oggi",
@@ -149,7 +189,17 @@ export const TRANSLATIONS = {
         resetDataDescription: "Rimuove colori, lingua, evidenziazione e tema salvati.",
         resetConfirmation: "Eliminare le impostazioni salvate del calendario? L'operazione è irreversibile.",
         trimUnusedHours: "Riduci ore vuote",
-        trimUnusedHoursDescription: "Nasconde le ore mattutine e serali senza eventi."
+        trimUnusedHoursDescription: "Nasconde le ore mattutine e serali senza eventi.",
+        noCalendarsTitle: "Nessun calendario trovato",
+        noCalendarsDescription: "Home Assistant non ha ancora registrato entità calendario, quindi la scheda non può mostrare nulla.",
+        noCalendarsStepsIntro: "Per risolvere:",
+        noCalendarsStepIntegrations: "Apri Impostazioni → Dispositivi e servizi → Integrazioni.",
+        noCalendarsStepAdd: "Aggiungi un'integrazione calendario come Calendario locale, Google Calendar, CalDAV o un altro provider utilizzato.",
+        noCalendarsStepVerify: "Attendi che compaia almeno un'entità `calendar.*`, poi torna a questa dashboard e aggiorna la scheda.",
+        noCalendarsLinksTitle: "Hai bisogno di aiuto?",
+        noCalendarsOpenIntegrations: "Apri Integrazioni",
+        noCalendarsReadGuide: "Leggi la guida di configurazione",
+        noCalendarsRefresh: "Controlla di nuovo"
     },
     nl: {
         today: "Vandaag",
@@ -179,7 +229,17 @@ export const TRANSLATIONS = {
         resetDataDescription: "Verwijdert opgeslagen kleuren, taal, markering en thema-instellingen.",
         resetConfirmation: "Opgeslagen kalenderinstellingen wissen? Dit kan niet ongedaan worden gemaakt.",
         trimUnusedHours: "Lege uren inkorten",
-        trimUnusedHoursDescription: "Verbergt vroege en late uren zonder afspraken."
+        trimUnusedHoursDescription: "Verbergt vroege en late uren zonder afspraken.",
+        noCalendarsTitle: "Geen agenda's gevonden",
+        noCalendarsDescription: "Home Assistant heeft nog geen agenda-entiteiten geregistreerd, waardoor de kaart niets kan tonen.",
+        noCalendarsStepsIntro: "Los dit op door het volgende te doen:",
+        noCalendarsStepIntegrations: "Open Instellingen → Apparaten en services → Integraties.",
+        noCalendarsStepAdd: "Voeg een agenda-integratie toe, zoals Lokale agenda, Google Agenda, CalDAV of een andere aanbieder.",
+        noCalendarsStepVerify: "Wacht tot er minstens één `calendar.*`-entiteit verschijnt en keer dan terug naar dit dashboard om de kaart te vernieuwen.",
+        noCalendarsLinksTitle: "Hulp nodig?",
+        noCalendarsOpenIntegrations: "Integraties openen",
+        noCalendarsReadGuide: "Setup-handleiding lezen",
+        noCalendarsRefresh: "Opnieuw controleren"
     }
 };
 


### PR DESCRIPTION
## Summary
- introduce a guided dialog that appears when Home Assistant has no `calendar.*` entities, including step-by-step instructions plus quick links to integrations and the README section
- hook the dialog into calendar discovery and refresh flows so it opens automatically when needed and dismisses itself once calendars exist
- add the necessary localization strings for every supported language and rebuild the distributable bundle

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69173d4c3b4883288db10285474c1505)