### PR TITLE
Fix all-day event timezone handling

### DIFF
--- a/calendar-week-card.js
+++ b/calendar-week-card.js
@@ -641,6 +641,20 @@ class CalendarWeekCard extends HTMLElement {
         }
     }
 
+    parseAllDayDate(dateString) {
+        if (!dateString || typeof dateString !== "string") {
+            return new Date(dateString || Date.now());
+        }
+
+        const parts = dateString.split("-").map(Number);
+        if (parts.length === 3 && parts.every(num => Number.isFinite(num))) {
+            const [year, month, day] = parts;
+            return new Date(year, month - 1, day);
+        }
+
+        return new Date(dateString);
+    }
+
     initializeThemePreference() {
         let storedThemePreference = null;
         try {
@@ -1756,9 +1770,15 @@ class CalendarWeekCard extends HTMLElement {
                 const url = `calendars/${entity}?start=${start.toISOString()}&end=${end.toISOString()}`;
                 const events = await hass.callApi("get", url);
                 events.forEach(ev => {
-                    const startDate = new Date(ev.start.dateTime || ev.start.date);
-                    const endDate = new Date(ev.end.dateTime || ev.end.date);
-                    let isAllDay = !!ev.start?.date && !ev.start?.dateTime;
+                    const startIsDateOnly = !!ev.start?.date && !ev.start?.dateTime;
+                    const endIsDateOnly = !!ev.end?.date && !ev.end?.dateTime;
+                    const startDate = startIsDateOnly
+                        ? this.parseAllDayDate(ev.start.date)
+                        : new Date(ev.start.dateTime || ev.start.date);
+                    const endDate = endIsDateOnly
+                        ? this.parseAllDayDate(ev.end.date)
+                        : new Date(ev.end.dateTime || ev.end.date);
+                    let isAllDay = startIsDateOnly || endIsDateOnly;
 
                     if (!isAllDay && ev.start?.dateTime && ev.end?.dateTime) {
                         const durationMinutes = (endDate - startDate) / (1000 * 60);

--- a/dist/calendar-week-card.js
+++ b/dist/calendar-week-card.js
@@ -641,6 +641,20 @@ class CalendarWeekCard extends HTMLElement {
         }
     }
 
+    parseAllDayDate(dateString) {
+        if (!dateString || typeof dateString !== "string") {
+            return new Date(dateString || Date.now());
+        }
+
+        const parts = dateString.split("-").map(Number);
+        if (parts.length === 3 && parts.every(num => Number.isFinite(num))) {
+            const [year, month, day] = parts;
+            return new Date(year, month - 1, day);
+        }
+
+        return new Date(dateString);
+    }
+
     initializeThemePreference() {
         let storedThemePreference = null;
         try {
@@ -1756,9 +1770,15 @@ class CalendarWeekCard extends HTMLElement {
                 const url = `calendars/${entity}?start=${start.toISOString()}&end=${end.toISOString()}`;
                 const events = await hass.callApi("get", url);
                 events.forEach(ev => {
-                    const startDate = new Date(ev.start.dateTime || ev.start.date);
-                    const endDate = new Date(ev.end.dateTime || ev.end.date);
-                    let isAllDay = !!ev.start?.date && !ev.start?.dateTime;
+                    const startIsDateOnly = !!ev.start?.date && !ev.start?.dateTime;
+                    const endIsDateOnly = !!ev.end?.date && !ev.end?.dateTime;
+                    const startDate = startIsDateOnly
+                        ? this.parseAllDayDate(ev.start.date)
+                        : new Date(ev.start.dateTime || ev.start.date);
+                    const endDate = endIsDateOnly
+                        ? this.parseAllDayDate(ev.end.date)
+                        : new Date(ev.end.dateTime || ev.end.date);
+                    let isAllDay = startIsDateOnly || endIsDateOnly;
 
                     if (!isAllDay && ev.start?.dateTime && ev.end?.dateTime) {
                         const durationMinutes = (endDate - startDate) / (1000 * 60);


### PR DESCRIPTION
## Summary
- add a helper that parses all-day event dates using the local timezone
- use the helper when loading events so all-day entries stay on the correct day
- rebuild the distributed bundles

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c5d4c00ac8328b60a3e1ba1ac7b01)