### PR TITLE
Refactor build script to inline modules

### DIFF
--- a/calendar-week-card.js
+++ b/calendar-week-card.js
@@ -1,6 +1,6 @@
 // Calendar Week Card – generated bundle
 
-// Localization
+// File: localization.js
 const FALLBACK_LANGUAGE = "en";
 
 const TRANSLATIONS = {
@@ -316,7 +316,7 @@ function getLanguageOptions() {
     return SUPPORTED_LANGUAGES.map(code => ({ code, label: LANGUAGE_NAMES[code] || code }));
 }
 
-// Color utilities
+// File: colors.js
 const HEX_PATTERN = /^#([0-9a-fA-F]{3,8})$/;
 
 function clampColorValue(value) {
@@ -478,7 +478,7 @@ function getHexColor(color, fallback = "#4287f5", resolverElement) {
     return "#4287f5";
 }
 
-// Calendar week card
+// File: calendar-week-card.js
 const THEME_VARIABLES = {
     light: {
         "--cwc-primary-text": "#1f1f1f",
@@ -2951,8 +2951,10 @@ class CalendarWeekCard extends HTMLElement {
     }
 }
 
+// File: index.js
 if (!customElements.get("calendar-week-card")) {
     customElements.define("calendar-week-card", CalendarWeekCard);
 }
+
 
 export { CalendarWeekCard };

--- a/dist/calendar-week-card.js
+++ b/dist/calendar-week-card.js
@@ -1,6 +1,6 @@
 // Calendar Week Card – generated bundle
 
-// Localization
+// File: localization.js
 const FALLBACK_LANGUAGE = "en";
 
 const TRANSLATIONS = {
@@ -316,7 +316,7 @@ function getLanguageOptions() {
     return SUPPORTED_LANGUAGES.map(code => ({ code, label: LANGUAGE_NAMES[code] || code }));
 }
 
-// Color utilities
+// File: colors.js
 const HEX_PATTERN = /^#([0-9a-fA-F]{3,8})$/;
 
 function clampColorValue(value) {
@@ -478,7 +478,7 @@ function getHexColor(color, fallback = "#4287f5", resolverElement) {
     return "#4287f5";
 }
 
-// Calendar week card
+// File: calendar-week-card.js
 const THEME_VARIABLES = {
     light: {
         "--cwc-primary-text": "#1f1f1f",
@@ -2951,8 +2951,10 @@ class CalendarWeekCard extends HTMLElement {
     }
 }
 
+// File: index.js
 if (!customElements.get("calendar-week-card")) {
     customElements.define("calendar-week-card", CalendarWeekCard);
 }
+
 
 export { CalendarWeekCard };

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,21 +1,22 @@
 import { mkdir, readFile, writeFile, copyFile } from "fs/promises";
 import { exec } from "child_process";
-const copyToClipboard = text =>
-    new Promise(res => exec(`printf "${text}" | pbcopy`, () => res()));
-
 import path from "path";
 import { fileURLToPath } from "url";
+
+const copyToClipboard = text =>
+    new Promise(res => exec(`printf "${text}" | pbcopy`, () => res()));
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, "..");
 const srcDir = path.join(rootDir, "src");
 const distDir = path.join(rootDir, "dist");
-
-// dist output (wie vorher)
 const outputFile = path.join(distDir, "calendar-week-card.js");
-
-// zusätzlich: Ziel für HACS (Repo-Root)
 const hacsOutputFile = path.join(rootDir, "calendar-week-card.js");
+
+const IMPORT_PATTERN = /import\s+(?:[^'";]+?from\s+)?["']([^"']+)["'];?|import\s+["']([^"']+)["'];?/g;
+const EXPORT_DECL_PATTERN = /export\s+(?=class|function|const|let|var)/g;
+const EXPORT_DEFAULT_PATTERN = /export\s+default\s+/g;
+const EXPORT_LIST_PATTERN = /export\s+\{[^}]+\};?/g;
 
 async function getBuildNumber() {
     const file = path.join(rootDir, "scripts/build-number.txt");
@@ -25,67 +26,78 @@ async function getBuildNumber() {
         await writeFile(file, String(next));
         return next;
     } catch {
-        // Datei existiert nicht → neu anlegen mit 1
         await writeFile(file, "1");
         return 1;
     }
 }
 
-function stripExports(source) {
-    return source
-        .replace(/export\s+default\s+/g, "")
-        .replace(/export\s+class\s+/g, "class ")
-        .replace(/export\s+const\s+/g, "const ")
-        .replace(/export\s+function\s+/g, "function ")
-        .replace(/export\s+\{[^}]+\};?/g, "");
+function resolveDependency(currentFile, specifier) {
+    if (!specifier || !specifier.startsWith(".")) {
+        return null;
+    }
+
+    const currentDir = path.dirname(currentFile);
+    const withExtension = specifier.endsWith(".js") ? specifier : `${specifier}.js`;
+    const resolved = path.normalize(path.join(currentDir, withExtension));
+    return resolved;
 }
 
-function stripImports(source) {
-    return source.replace(/^import[^;]+;\n?/gm, "").trimStart();
+function transformSource(source) {
+    const dependencies = [];
+    const withoutImports = source.replace(IMPORT_PATTERN, (match, fromA, fromB) => {
+        const specifier = fromA || fromB;
+        dependencies.push(specifier);
+        return "";
+    });
+
+    const withoutExports = withoutImports
+        .replace(EXPORT_DEFAULT_PATTERN, "")
+        .replace(EXPORT_DECL_PATTERN, "")
+        .replace(EXPORT_LIST_PATTERN, "");
+
+    return {
+        code: withoutExports.trimStart(),
+        dependencies
+    };
 }
 
-async function readSource(relativePath) {
-    const filePath = path.join(srcDir, relativePath);
-    return readFile(filePath, "utf8");
-}
+async function bundleFile(entry) {
+    const visited = new Set();
+    const sections = [];
 
-function wrapSection(title, content) {
-    const trimmed = content.trim();
-    return trimmed ? `// ${title}\n${trimmed}` : "";
+    async function visit(relativePath) {
+        if (visited.has(relativePath)) {
+            return;
+        }
+        visited.add(relativePath);
+
+        const absolutePath = path.join(srcDir, relativePath);
+        const source = await readFile(absolutePath, "utf8");
+        const { code, dependencies } = transformSource(source);
+
+        for (const rawDependency of dependencies) {
+            const resolved = resolveDependency(relativePath, rawDependency);
+            if (resolved) {
+                await visit(resolved);
+            }
+        }
+
+        sections.push(`// File: ${relativePath}\n${code.trim()}\n`);
+    }
+
+    await visit(entry);
+    return sections.join("\n");
 }
 
 async function build() {
-    const [localizationSource, colorsSource, cardSource] = await Promise.all([
-        readSource("localization.js"),
-        readSource("colors.js"),
-        readSource("calendar-week-card.js")
-    ]);
-
-    const localization = stripExports(localizationSource);
-    const colors = stripExports(colorsSource);
-    const card = stripImports(stripExports(cardSource));
+    await mkdir(distDir, { recursive: true });
+    const bundle = await bundleFile("index.js");
 
     const banner = "// Calendar Week Card – generated bundle";
-    const registration = [
-        "if (!customElements.get(\"calendar-week-card\")) {",
-        "    customElements.define(\"calendar-week-card\", CalendarWeekCard);",
-        "}",
-        "",
-        "export { CalendarWeekCard };"
-    ].join("\n");
+    const footer = "export { CalendarWeekCard };";
+    const output = [banner, bundle, footer].filter(Boolean).join("\n\n");
 
-    const sections = [
-        banner,
-        wrapSection("Localization", localization),
-        wrapSection("Color utilities", colors),
-        wrapSection("Calendar week card", card),
-        registration
-    ].filter(Boolean);
-
-    await mkdir(distDir, { recursive: true });
-    await writeFile(outputFile, sections.join("\n\n") + "\n", "utf8");
-
-    // *** HIER: Datei zusätzlich an HACS-Ziel kopieren ***
+    await writeFile(outputFile, `${output}\n`, "utf8");
     await copyFile(outputFile, hacsOutputFile);
 
     console.log(`Built ${path.relative(rootDir, outputFile)}`);
@@ -96,7 +108,6 @@ async function build() {
     await copyToClipboard(versionedPath);
     console.log("\nPath:");
     console.log(versionedPath);
-
 }
 
 build().catch(err => {


### PR DESCRIPTION
## Summary
- replace the brittle regex "strip" helpers with a tiny dependency-aware bundler that walks the module graph starting at `src/index.js`
- regenerate the distributable bundle and the root copy using the new build output

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c9422755c832881825f0572cebaba)