### PR TITLE
Refactor build bundling

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,7 +1,8 @@
-import { mkdir, readFile, writeFile, copyFile } from "fs/promises";
-import { exec } from "child_process";
+import { copyFile, mkdir, readFile, writeFile } from "fs/promises";
+import { exec, spawn } from "child_process";
 import path from "path";
-import { fileURLToPath } from "url";
+import vm from "vm";
+import { fileURLToPath, pathToFileURL } from "url";
 
 const copyToClipboard = text =>
     new Promise(res => exec(`printf "${text}" | pbcopy`, () => res()));
@@ -12,11 +13,6 @@ const srcDir = path.join(rootDir, "src");
 const distDir = path.join(rootDir, "dist");
 const outputFile = path.join(distDir, "calendar-week-card.js");
 const hacsOutputFile = path.join(rootDir, "calendar-week-card.js");
-
-const IMPORT_PATTERN = /import\s+(?:[^'";]+?from\s+)?["']([^"']+)["'];?|import\s+["']([^"']+)["'];?/g;
-const EXPORT_DECL_PATTERN = /export\s+(?=class|function|const|let|var)/g;
-const EXPORT_DEFAULT_PATTERN = /export\s+default\s+/g;
-const EXPORT_LIST_PATTERN = /export\s+\{[^}]+\};?/g;
 
 async function getBuildNumber() {
     const file = path.join(rootDir, "scripts/build-number.txt");
@@ -31,70 +27,81 @@ async function getBuildNumber() {
     }
 }
 
-function resolveDependency(currentFile, specifier) {
-    if (!specifier || !specifier.startsWith(".")) {
-        return null;
-    }
-
-    const currentDir = path.dirname(currentFile);
-    const withExtension = specifier.endsWith(".js") ? specifier : `${specifier}.js`;
-    const resolved = path.normalize(path.join(currentDir, withExtension));
-    return resolved;
+function stripModuleSyntax(source) {
+    return source
+        .replace(/^\s*import[^;]*;\s*/gm, "")
+        .replace(/export\s+default\s+/g, "")
+        .replace(/export\s+(?=class|function|const|let|var)/g, "")
+        .replace(/export\s+\{[^}]+\};?/g, "");
 }
 
-function transformSource(source) {
-    const dependencies = [];
-    const withoutImports = source.replace(IMPORT_PATTERN, (match, fromA, fromB) => {
-        const specifier = fromA || fromB;
-        dependencies.push(specifier);
-        return "";
+async function collectModule(relativePath, visited, sections) {
+    const absolutePath = path.join(srcDir, relativePath);
+    if (visited.has(absolutePath)) {
+        return;
+    }
+
+    visited.add(absolutePath);
+    const source = await readFile(absolutePath, "utf8");
+    const module = new vm.SourceTextModule(source, {
+        identifier: pathToFileURL(absolutePath).href
     });
 
-    const withoutExports = withoutImports
-        .replace(EXPORT_DEFAULT_PATTERN, "")
-        .replace(EXPORT_DECL_PATTERN, "")
-        .replace(EXPORT_LIST_PATTERN, "");
-
-    return {
-        code: withoutExports.trimStart(),
-        dependencies
-    };
-}
-
-async function bundleFile(entry) {
-    const visited = new Set();
-    const sections = [];
-
-    async function visit(relativePath) {
-        if (visited.has(relativePath)) {
-            return;
-        }
-        visited.add(relativePath);
-
-        const absolutePath = path.join(srcDir, relativePath);
-        const source = await readFile(absolutePath, "utf8");
-        const { code, dependencies } = transformSource(source);
-
-        for (const rawDependency of dependencies) {
-            const resolved = resolveDependency(relativePath, rawDependency);
-            if (resolved) {
-                await visit(resolved);
-            }
+    for (const specifier of module.dependencySpecifiers) {
+        if (!specifier.startsWith(".")) {
+            continue;
         }
 
-        sections.push(`// File: ${relativePath}\n${code.trim()}\n`);
+        const resolvedUrl = new URL(specifier, module.identifier);
+        const resolvedPath = path.relative(srcDir, fileURLToPath(resolvedUrl));
+        await collectModule(resolvedPath, visited, sections);
     }
 
-    await visit(entry);
+    sections.push(`// File: ${relativePath}\n${stripModuleSyntax(source).trim()}\n`);
+}
+
+async function createBundle() {
+    const visited = new Set();
+    const sections = [];
+    await collectModule("index.js", visited, sections);
     return sections.join("\n");
 }
 
+async function ensureVmModules() {
+    if (process.execArgv.includes("--experimental-vm-modules")) {
+        return null;
+    }
+
+    return new Promise((resolve, reject) => {
+        const child = spawn(process.execPath, [
+            "--experimental-vm-modules",
+            fileURLToPath(import.meta.url)
+        ], {
+            stdio: "inherit",
+            env: process.env
+        });
+
+        child.on("exit", code => {
+            if (code === 0) {
+                resolve(code);
+            } else {
+                reject(new Error(`Build failed with exit code ${code}`));
+            }
+        });
+    });
+}
+
 async function build() {
+    const delegated = await ensureVmModules();
+    if (delegated !== null) {
+        return;
+    }
+
     await mkdir(distDir, { recursive: true });
-    const bundle = await bundleFile("index.js");
 
     const banner = "// Calendar Week Card – generated bundle";
     const footer = "export { CalendarWeekCard };";
+    const bundle = await createBundle();
     const output = [banner, bundle, footer].filter(Boolean).join("\n\n");
 
     await writeFile(outputFile, `${output}\n`, "utf8");


### PR DESCRIPTION
## Summary
- replace the custom regex-based bundling logic with a VM-powered module graph walker
- keep banner/footer handling while building the single-file bundle from the src entry
- maintain the HACS copy step and versioned path clipboard helper

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920268b07f48328b2347bc447c25ccf)