### PR TITLE
Improve card sizing based on rendered height

### DIFF
--- a/calendar-week-card.js
+++ b/calendar-week-card.js
@@ -3489,7 +3489,20 @@ class CalendarWeekCard extends HTMLElement {
     }
 
     getCardSize() {
-        return 3;
+        const measuredHeight = typeof this.getBoundingClientRect === "function"
+            ? this.getBoundingClientRect().height
+            : 0;
+
+        if (measuredHeight > 0) {
+            return Math.ceil(measuredHeight / 50);
+        }
+
+        const configuredRows = this?.config?.grid_options?.rows;
+        if (typeof configuredRows === "number") {
+            return configuredRows;
+        }
+
+        return 6;
     }
 
     static getStubConfig(hass) {

--- a/dist/calendar-week-card.js
+++ b/dist/calendar-week-card.js
@@ -3489,7 +3489,20 @@ class CalendarWeekCard extends HTMLElement {
     }
 
     getCardSize() {
-        return 3;
+        const measuredHeight = typeof this.getBoundingClientRect === "function"
+            ? this.getBoundingClientRect().height
+            : 0;
+
+        if (measuredHeight > 0) {
+            return Math.ceil(measuredHeight / 50);
+        }
+
+        const configuredRows = this?.config?.grid_options?.rows;
+        if (typeof configuredRows === "number") {
+            return configuredRows;
+        }
+
+        return 6;
     }
 
     static getStubConfig(hass) {

--- a/src/calendar-week-card.js
+++ b/src/calendar-week-card.js
@@ -2962,7 +2962,20 @@ export class CalendarWeekCard extends HTMLElement {
     }
 
     getCardSize() {
-        return 3;
+        const measuredHeight = typeof this.getBoundingClientRect === "function"
+            ? this.getBoundingClientRect().height
+            : 0;
+
+        if (measuredHeight > 0) {
+            return Math.ceil(measuredHeight / 50);
+        }
+
+        const configuredRows = this?.config?.grid_options?.rows;
+        if (typeof configuredRows === "number") {
+            return configuredRows;
+        }
+
+        return 6;
     }
 
     static getStubConfig(hass) {


### PR DESCRIPTION
## Summary
- update getCardSize to derive size from the rendered height with sensible fallbacks
- rebuild the bundled outputs to include the new sizing logic

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693cb095be2083288e44037c8826b1fa)