### PR TITLE
Make host sizing configurable for container layouts

### DIFF
--- a/calendar-week-card.js
+++ b/calendar-week-card.js
@@ -1366,8 +1366,9 @@ class CalendarWeekCard extends HTMLElement {
             :host {
                 display: flex;
                 flex-direction: column;
-                height: 100%;
-                max-height: 100vh;
+                height: var(--cwc-height, auto);
+                min-height: var(--cwc-min-height, 100%);
+                max-height: var(--cwc-max-height, none);
                 width: 100%;
                 box-sizing: border-box;
                 font-family: var(--primary-font-family, "Roboto", "Helvetica", sans-serif);

--- a/dist/calendar-week-card.js
+++ b/dist/calendar-week-card.js
@@ -1366,8 +1366,9 @@ class CalendarWeekCard extends HTMLElement {
             :host {
                 display: flex;
                 flex-direction: column;
-                height: 100%;
-                max-height: 100vh;
+                height: var(--cwc-height, auto);
+                min-height: var(--cwc-min-height, 100%);
+                max-height: var(--cwc-max-height, none);
                 width: 100%;
                 box-sizing: border-box;
                 font-family: var(--primary-font-family, "Roboto", "Helvetica", sans-serif);

--- a/src/calendar-week-card.js
+++ b/src/calendar-week-card.js
@@ -839,8 +839,9 @@ export class CalendarWeekCard extends HTMLElement {
             :host {
                 display: flex;
                 flex-direction: column;
-                height: 100%;
-                max-height: 100vh;
+                height: var(--cwc-height, auto);
+                min-height: var(--cwc-min-height, 100%);
+                max-height: var(--cwc-max-height, none);
                 width: 100%;
                 box-sizing: border-box;
                 font-family: var(--primary-font-family, "Roboto", "Helvetica", sans-serif);


### PR DESCRIPTION
## Summary
- replace the card host's fixed height and max-height with configurable CSS variables that default to container-friendly sizing
- rebuild the distributed bundle to propagate the host sizing change

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d6acddd38832897f73d1dd493c3af)