### PR TITLE
Let calendar week card grow to content

### DIFF
--- a/calendar-week-card.js
+++ b/calendar-week-card.js
@@ -1418,6 +1418,15 @@ class CalendarWeekCard extends HTMLElement {
                 --cwc-dialog-divider: rgba(255, 255, 255, 0.12);
                 --cwc-today-glow: rgba(77, 150, 255, 0.35);
             }
+            .card-root {
+                position: relative;
+                display: flex;
+                flex-direction: column;
+                width: 100%;
+                height: 100%;
+                max-height: 100%;
+                box-sizing: border-box;
+            }
             .header-bar {
                 display: flex;
                 align-items: center;
@@ -1487,6 +1496,7 @@ class CalendarWeekCard extends HTMLElement {
             .week-body {
                 display: flex;
                 width: 100%;
+                flex: 1 1 auto;
                 background: var(--cwc-week-bg);
                 min-height: var(--cwc-viewport-height);
                 gap: 0;
@@ -1777,27 +1787,30 @@ class CalendarWeekCard extends HTMLElement {
             }
         </style>
 
-        <div class="header-bar">
-          <div class="nav-buttons">
-            <button class="prev-week">◀</button>
-            <button class="today"></button>
-            <button class="next-week">▶</button>
-          </div>
-          <h3 class="title-line"></h3>
-          <span class="settings-icon">⚙️</span>
-        </div>
-
-        <div class="week-header"></div>
-
-        <div class="week-body">
-            <div class="time-bar"></div>
-            <div class="week-grid">
-                ${[...Array(7)].map(() => `<div class="day-column"></div>`).join("")}
+        <div class="card-root">
+            <div class="header-bar">
+              <div class="nav-buttons">
+                <button class="prev-week">◀</button>
+                <button class="today"></button>
+                <button class="next-week">▶</button>
+              </div>
+              <h3 class="title-line"></h3>
+              <span class="settings-icon">⚙️</span>
             </div>
+
+            <div class="week-header"></div>
+
+            <div class="week-body">
+                <div class="time-bar"></div>
+                <div class="week-grid">
+                    ${[...Array(7)].map(() => `<div class="day-column"></div>`).join("")}
+                </div>
+            </div>
+            <div class="no-calendars-inline" hidden></div>
         </div>
-        <div class="no-calendars-inline" hidden></div>
         `;
 
+        this.cardRoot = this.shadowRoot.querySelector(".card-root");
         this.grid = this.shadowRoot.querySelector(".week-grid");
         this.timeBar = this.shadowRoot.querySelector(".time-bar");
         this.header = this.shadowRoot.querySelector(".week-header");
@@ -2496,7 +2509,10 @@ class CalendarWeekCard extends HTMLElement {
             this.shadowRoot?.querySelector(".header-bar")?.offsetHeight || 0;
         const root = typeof document !== "undefined" ? document.getElementById("root") : null;
         const rootRect = root?.getBoundingClientRect?.();
-        const maxViewportHeight = rootRect?.height || root?.clientHeight || root?.offsetHeight || null;
+        const rootHeight = rootRect?.height || root?.clientHeight || root?.offsetHeight || null;
+        const containerHeight = this.cardRoot?.getBoundingClientRect?.()?.height || this.cardRoot?.clientHeight ||
+            this.cardRoot?.offsetHeight || null;
+        const maxViewportHeight = rootHeight || containerHeight || null;
 
         if (!viewportHeight && this.grid) {
             const rect = this.grid.getBoundingClientRect();
@@ -2523,6 +2539,15 @@ class CalendarWeekCard extends HTMLElement {
             const availableHeight = Math.max(maxViewportHeight - headerHeight - this.columnPaddingTop - this.columnPaddingBottom, 0);
             if (availableHeight > 0) {
                 viewportHeight = Math.min(viewportHeight, availableHeight);
+            }
+        }
+        if (this.cardRoot) {
+            if (maxViewportHeight && maxViewportHeight > 0) {
+                this.cardRoot.style.height = `${maxViewportHeight}px`;
+                this.cardRoot.style.maxHeight = `${maxViewportHeight}px`;
+            } else {
+                this.cardRoot.style.removeProperty("height");
+                this.cardRoot.style.removeProperty("max-height");
             }
         }
         this.timeViewportHeight = viewportHeight;

--- a/calendar-week-card.js
+++ b/calendar-week-card.js
@@ -2520,7 +2520,7 @@ class CalendarWeekCard extends HTMLElement {
 
         viewportHeight = Math.max(viewportHeight, rawVisibleDuration);
         if (maxViewportHeight && maxViewportHeight > 0) {
-            const availableHeight = Math.max(maxViewportHeight - headerHeight, 0);
+            const availableHeight = Math.max(maxViewportHeight - headerHeight - this.columnPaddingTop - this.columnPaddingBottom, 0);
             if (availableHeight > 0) {
                 viewportHeight = Math.min(viewportHeight, availableHeight);
             }

--- a/calendar-week-card.js
+++ b/calendar-week-card.js
@@ -1362,15 +1362,11 @@ class CalendarWeekCard extends HTMLElement {
         this.shadowRoot.innerHTML = `
         <style>
             :host {
-                display: flex;
-                flex-direction: column;
-                height: 100%;
-                max-height: 100vh;
+                display: block;
                 width: 100%;
                 box-sizing: border-box;
                 font-family: var(--primary-font-family, "Roboto", "Helvetica", sans-serif);
                 color: var(--cwc-primary-text, var(--primary-text-color, #1f1f1f));
-                overflow: hidden;
                 background: var(--cwc-background, var(--card-background-color, #ffffff));
                 --cwc-primary-text: var(--primary-text-color, #1f1f1f);
                 --cwc-secondary-text: var(--secondary-text-color, #5f6368);
@@ -1395,6 +1391,7 @@ class CalendarWeekCard extends HTMLElement {
                 --cwc-dialog-muted: #555555;
                 --cwc-dialog-divider: rgba(0, 0, 0, 0.08);
                 --cwc-today-glow: rgba(77, 150, 255, 0.18);
+                --cwc-viewport-height: 480px;
             }
             :host(.theme-dark) {
                 --cwc-primary-text: #f5f7ff;
@@ -1488,13 +1485,11 @@ class CalendarWeekCard extends HTMLElement {
                 color: inherit;
             }
             .week-body {
-                flex: 1;
                 display: flex;
                 width: 100%;
-                height: 100%;
-                overflow: hidden;
                 background: var(--cwc-week-bg);
-                min-height: 0;
+                min-height: var(--cwc-viewport-height);
+                gap: 0;
             }
             .time-bar {
                 position: relative;
@@ -1503,8 +1498,8 @@ class CalendarWeekCard extends HTMLElement {
                 font-size: 11px;
                 background: var(--cwc-timebar-bg);
                 flex-shrink: 0;
-                overflow: hidden;
-                min-height: 0;
+                overflow: visible;
+                min-height: var(--cwc-viewport-height);
             }
             .hour-label {
                 position: absolute;
@@ -1518,11 +1513,10 @@ class CalendarWeekCard extends HTMLElement {
                 flex: 1;
                 display: grid;
                 grid-template-columns: repeat(7, 1fr);
-                height: 100%;
                 width: 100%;
                 overflow: visible;
                 background: var(--cwc-week-bg);
-                min-height: 50px;
+                min-height: var(--cwc-viewport-height);
             }
             .day-column {
                 position: relative;
@@ -1567,14 +1561,13 @@ class CalendarWeekCard extends HTMLElement {
                 position: relative;
                 flex: 1;
                 width: 100%;
-                min-height: 0;
+                min-height: var(--cwc-viewport-height);
                 overflow: visible;
             }
             .timed-events {
                 position: relative;
                 width: 100%;
-                height: 100%;
-                min-height: 0;
+                min-height: var(--cwc-viewport-height);
                 z-index: 1;
             }
             .event {
@@ -1880,8 +1873,9 @@ class CalendarWeekCard extends HTMLElement {
     buildTimeLabels() {
         if (!this.timeBar) return;
         this.timeBar.innerHTML = "";
-        this.timeBar.style.minHeight = "";
-        this.timeBar.style.height = "100%";
+        const paddedHeight = this.timeViewportHeight + this.columnPaddingTop + this.columnPaddingBottom;
+        this.timeBar.style.minHeight = `${paddedHeight}px`;
+        this.timeBar.style.height = `${paddedHeight}px`;
         this.timeBar.style.paddingTop = `${this.columnPaddingTop}px`;
         this.timeBar.style.paddingBottom = `${this.columnPaddingBottom}px`;
         const visibleStart = this.visibleStartMinute || 0;
@@ -2276,6 +2270,26 @@ class CalendarWeekCard extends HTMLElement {
 
         this.allDayBandHeight = 0;
         this.updateTimeMetrics();
+        const paddedViewportHeight = this.timeViewportHeight + this.columnPaddingTop + this.columnPaddingBottom;
+        if (this.weekBody) {
+            this.weekBody.style.minHeight = `${paddedViewportHeight}px`;
+        }
+        if (this.grid) {
+            this.grid.style.minHeight = `${paddedViewportHeight}px`;
+        }
+        this.dayColumns?.forEach(column => {
+            const timedViewport = column.querySelector(".timed-viewport");
+            const timedEvents = column.querySelector(".timed-events");
+            if (timedViewport) {
+                timedViewport.style.minHeight = `${paddedViewportHeight}px`;
+                timedViewport.style.height = `${paddedViewportHeight}px`;
+                timedViewport.style.paddingTop = `${this.columnPaddingTop}px`;
+                timedViewport.style.paddingBottom = `${this.columnPaddingBottom}px`;
+            }
+            if (timedEvents) {
+                timedEvents.style.minHeight = `${paddedViewportHeight}px`;
+            }
+        });
 
         const highlightEnabled = this.config.highlight_today !== false;
         const highlightEdgeColor = this.getHexColor(this.config.today_highlight_color || "#4D96FF");
@@ -2470,7 +2484,12 @@ class CalendarWeekCard extends HTMLElement {
     }
 
     updateTimeMetrics() {
-        const fallbackViewport = Math.max(this.clientHeight || 0, this.grid?.clientHeight || 0, 480);
+        const totalMinutes = 24 * 60;
+        const rawVisibleDuration = Math.max(
+            (this.visibleEndMinute || totalMinutes) - (this.visibleStartMinute || 0),
+            1
+        );
+        const fallbackViewport = Math.max(this.clientHeight || 0, this.grid?.clientHeight || 0, rawVisibleDuration, 480);
         const firstViewport = this.dayColumns?.[0]?.querySelector(".timed-viewport");
         let viewportHeight = firstViewport?.clientHeight || firstViewport?.offsetHeight || 0;
 
@@ -2494,9 +2513,9 @@ class CalendarWeekCard extends HTMLElement {
             viewportHeight = fallbackViewport;
         }
 
+        viewportHeight = Math.max(viewportHeight, rawVisibleDuration);
         this.timeViewportHeight = viewportHeight;
         const effectiveHeight = Math.max(viewportHeight, 24);
-        const totalMinutes = 24 * 60;
         const visibleStart = Math.max(0, Math.min(Number(this.visibleStartMinute) || 0, totalMinutes - 1));
         const visibleEnd = Math.max(visibleStart + 1, Math.min(Number(this.visibleEndMinute) || totalMinutes, totalMinutes));
         const visibleDuration = Math.max(visibleEnd - visibleStart, 1);
@@ -2504,6 +2523,8 @@ class CalendarWeekCard extends HTMLElement {
         this.visibleEndMinute = visibleEnd;
         this.pixelsPerMinute = effectiveHeight / visibleDuration;
         this.timeAxisOffset = this.columnPaddingTop - visibleStart * this.pixelsPerMinute;
+        const paddedViewportHeight = viewportHeight + this.columnPaddingTop + this.columnPaddingBottom;
+        this.style.setProperty("--cwc-viewport-height", `${paddedViewportHeight}px`);
     }
 
     colorWithAlpha(color, alpha = 1) {
@@ -3487,7 +3508,21 @@ class CalendarWeekCard extends HTMLElement {
     }
 
     getCardSize() {
-        return 20;
+        const header = this.shadowRoot?.querySelector(".header-bar");
+        const body = this.shadowRoot?.querySelector(".week-body");
+        const inlineEmpty = this.shadowRoot?.querySelector(".no-calendars-inline");
+        const headerHeight = header?.scrollHeight || header?.clientHeight || 0;
+        const bodyHeight = body?.scrollHeight || body?.clientHeight || 0;
+        const emptyHeight = inlineEmpty && !inlineEmpty.hidden ? (inlineEmpty.scrollHeight || inlineEmpty.clientHeight || 0) : 0;
+        const measured = headerHeight + Math.max(bodyHeight, emptyHeight);
+        if (measured > 0) {
+            return Math.ceil(measured / 50);
+        }
+
+        const totalMinutes = 24 * 60;
+        const visibleDuration = Math.max((this.visibleEndMinute || totalMinutes) - (this.visibleStartMinute || 0), 1);
+        const estimatedHeight = Math.max(this.timeViewportHeight || visibleDuration, 480);
+        return Math.ceil(estimatedHeight / 50);
     }
 
     static getStubConfig(hass) {

--- a/calendar-week-card.js
+++ b/calendar-week-card.js
@@ -2492,6 +2492,11 @@ class CalendarWeekCard extends HTMLElement {
         const fallbackViewport = Math.max(this.clientHeight || 0, this.grid?.clientHeight || 0, rawVisibleDuration, 480);
         const firstViewport = this.dayColumns?.[0]?.querySelector(".timed-viewport");
         let viewportHeight = firstViewport?.clientHeight || firstViewport?.offsetHeight || 0;
+        const headerHeight = this.shadowRoot?.querySelector(".header-bar")?.getBoundingClientRect?.()?.height ||
+            this.shadowRoot?.querySelector(".header-bar")?.offsetHeight || 0;
+        const root = typeof document !== "undefined" ? document.getElementById("root") : null;
+        const rootRect = root?.getBoundingClientRect?.();
+        const maxViewportHeight = rootRect?.height || root?.clientHeight || root?.offsetHeight || null;
 
         if (!viewportHeight && this.grid) {
             const rect = this.grid.getBoundingClientRect();
@@ -2514,6 +2519,12 @@ class CalendarWeekCard extends HTMLElement {
         }
 
         viewportHeight = Math.max(viewportHeight, rawVisibleDuration);
+        if (maxViewportHeight && maxViewportHeight > 0) {
+            const availableHeight = Math.max(maxViewportHeight - headerHeight, 0);
+            if (availableHeight > 0) {
+                viewportHeight = Math.min(viewportHeight, availableHeight);
+            }
+        }
         this.timeViewportHeight = viewportHeight;
         const effectiveHeight = Math.max(viewportHeight, 24);
         const visibleStart = Math.max(0, Math.min(Number(this.visibleStartMinute) || 0, totalMinutes - 1));

--- a/dist/calendar-week-card.js
+++ b/dist/calendar-week-card.js
@@ -1418,6 +1418,15 @@ class CalendarWeekCard extends HTMLElement {
                 --cwc-dialog-divider: rgba(255, 255, 255, 0.12);
                 --cwc-today-glow: rgba(77, 150, 255, 0.35);
             }
+            .card-root {
+                position: relative;
+                display: flex;
+                flex-direction: column;
+                width: 100%;
+                height: 100%;
+                max-height: 100%;
+                box-sizing: border-box;
+            }
             .header-bar {
                 display: flex;
                 align-items: center;
@@ -1487,6 +1496,7 @@ class CalendarWeekCard extends HTMLElement {
             .week-body {
                 display: flex;
                 width: 100%;
+                flex: 1 1 auto;
                 background: var(--cwc-week-bg);
                 min-height: var(--cwc-viewport-height);
                 gap: 0;
@@ -1777,27 +1787,30 @@ class CalendarWeekCard extends HTMLElement {
             }
         </style>
 
-        <div class="header-bar">
-          <div class="nav-buttons">
-            <button class="prev-week">◀</button>
-            <button class="today"></button>
-            <button class="next-week">▶</button>
-          </div>
-          <h3 class="title-line"></h3>
-          <span class="settings-icon">⚙️</span>
-        </div>
-
-        <div class="week-header"></div>
-
-        <div class="week-body">
-            <div class="time-bar"></div>
-            <div class="week-grid">
-                ${[...Array(7)].map(() => `<div class="day-column"></div>`).join("")}
+        <div class="card-root">
+            <div class="header-bar">
+              <div class="nav-buttons">
+                <button class="prev-week">◀</button>
+                <button class="today"></button>
+                <button class="next-week">▶</button>
+              </div>
+              <h3 class="title-line"></h3>
+              <span class="settings-icon">⚙️</span>
             </div>
+
+            <div class="week-header"></div>
+
+            <div class="week-body">
+                <div class="time-bar"></div>
+                <div class="week-grid">
+                    ${[...Array(7)].map(() => `<div class="day-column"></div>`).join("")}
+                </div>
+            </div>
+            <div class="no-calendars-inline" hidden></div>
         </div>
-        <div class="no-calendars-inline" hidden></div>
         `;
 
+        this.cardRoot = this.shadowRoot.querySelector(".card-root");
         this.grid = this.shadowRoot.querySelector(".week-grid");
         this.timeBar = this.shadowRoot.querySelector(".time-bar");
         this.header = this.shadowRoot.querySelector(".week-header");
@@ -2496,7 +2509,10 @@ class CalendarWeekCard extends HTMLElement {
             this.shadowRoot?.querySelector(".header-bar")?.offsetHeight || 0;
         const root = typeof document !== "undefined" ? document.getElementById("root") : null;
         const rootRect = root?.getBoundingClientRect?.();
-        const maxViewportHeight = rootRect?.height || root?.clientHeight || root?.offsetHeight || null;
+        const rootHeight = rootRect?.height || root?.clientHeight || root?.offsetHeight || null;
+        const containerHeight = this.cardRoot?.getBoundingClientRect?.()?.height || this.cardRoot?.clientHeight ||
+            this.cardRoot?.offsetHeight || null;
+        const maxViewportHeight = rootHeight || containerHeight || null;
 
         if (!viewportHeight && this.grid) {
             const rect = this.grid.getBoundingClientRect();
@@ -2523,6 +2539,15 @@ class CalendarWeekCard extends HTMLElement {
             const availableHeight = Math.max(maxViewportHeight - headerHeight - this.columnPaddingTop - this.columnPaddingBottom, 0);
             if (availableHeight > 0) {
                 viewportHeight = Math.min(viewportHeight, availableHeight);
+            }
+        }
+        if (this.cardRoot) {
+            if (maxViewportHeight && maxViewportHeight > 0) {
+                this.cardRoot.style.height = `${maxViewportHeight}px`;
+                this.cardRoot.style.maxHeight = `${maxViewportHeight}px`;
+            } else {
+                this.cardRoot.style.removeProperty("height");
+                this.cardRoot.style.removeProperty("max-height");
             }
         }
         this.timeViewportHeight = viewportHeight;

--- a/dist/calendar-week-card.js
+++ b/dist/calendar-week-card.js
@@ -2520,7 +2520,7 @@ class CalendarWeekCard extends HTMLElement {
 
         viewportHeight = Math.max(viewportHeight, rawVisibleDuration);
         if (maxViewportHeight && maxViewportHeight > 0) {
-            const availableHeight = Math.max(maxViewportHeight - headerHeight, 0);
+            const availableHeight = Math.max(maxViewportHeight - headerHeight - this.columnPaddingTop - this.columnPaddingBottom, 0);
             if (availableHeight > 0) {
                 viewportHeight = Math.min(viewportHeight, availableHeight);
             }

--- a/dist/calendar-week-card.js
+++ b/dist/calendar-week-card.js
@@ -1362,15 +1362,11 @@ class CalendarWeekCard extends HTMLElement {
         this.shadowRoot.innerHTML = `
         <style>
             :host {
-                display: flex;
-                flex-direction: column;
-                height: 100%;
-                max-height: 100vh;
+                display: block;
                 width: 100%;
                 box-sizing: border-box;
                 font-family: var(--primary-font-family, "Roboto", "Helvetica", sans-serif);
                 color: var(--cwc-primary-text, var(--primary-text-color, #1f1f1f));
-                overflow: hidden;
                 background: var(--cwc-background, var(--card-background-color, #ffffff));
                 --cwc-primary-text: var(--primary-text-color, #1f1f1f);
                 --cwc-secondary-text: var(--secondary-text-color, #5f6368);
@@ -1395,6 +1391,7 @@ class CalendarWeekCard extends HTMLElement {
                 --cwc-dialog-muted: #555555;
                 --cwc-dialog-divider: rgba(0, 0, 0, 0.08);
                 --cwc-today-glow: rgba(77, 150, 255, 0.18);
+                --cwc-viewport-height: 480px;
             }
             :host(.theme-dark) {
                 --cwc-primary-text: #f5f7ff;
@@ -1488,13 +1485,11 @@ class CalendarWeekCard extends HTMLElement {
                 color: inherit;
             }
             .week-body {
-                flex: 1;
                 display: flex;
                 width: 100%;
-                height: 100%;
-                overflow: hidden;
                 background: var(--cwc-week-bg);
-                min-height: 0;
+                min-height: var(--cwc-viewport-height);
+                gap: 0;
             }
             .time-bar {
                 position: relative;
@@ -1503,8 +1498,8 @@ class CalendarWeekCard extends HTMLElement {
                 font-size: 11px;
                 background: var(--cwc-timebar-bg);
                 flex-shrink: 0;
-                overflow: hidden;
-                min-height: 0;
+                overflow: visible;
+                min-height: var(--cwc-viewport-height);
             }
             .hour-label {
                 position: absolute;
@@ -1518,11 +1513,10 @@ class CalendarWeekCard extends HTMLElement {
                 flex: 1;
                 display: grid;
                 grid-template-columns: repeat(7, 1fr);
-                height: 100%;
                 width: 100%;
                 overflow: visible;
                 background: var(--cwc-week-bg);
-                min-height: 50px;
+                min-height: var(--cwc-viewport-height);
             }
             .day-column {
                 position: relative;
@@ -1567,14 +1561,13 @@ class CalendarWeekCard extends HTMLElement {
                 position: relative;
                 flex: 1;
                 width: 100%;
-                min-height: 0;
+                min-height: var(--cwc-viewport-height);
                 overflow: visible;
             }
             .timed-events {
                 position: relative;
                 width: 100%;
-                height: 100%;
-                min-height: 0;
+                min-height: var(--cwc-viewport-height);
                 z-index: 1;
             }
             .event {
@@ -1880,8 +1873,9 @@ class CalendarWeekCard extends HTMLElement {
     buildTimeLabels() {
         if (!this.timeBar) return;
         this.timeBar.innerHTML = "";
-        this.timeBar.style.minHeight = "";
-        this.timeBar.style.height = "100%";
+        const paddedHeight = this.timeViewportHeight + this.columnPaddingTop + this.columnPaddingBottom;
+        this.timeBar.style.minHeight = `${paddedHeight}px`;
+        this.timeBar.style.height = `${paddedHeight}px`;
         this.timeBar.style.paddingTop = `${this.columnPaddingTop}px`;
         this.timeBar.style.paddingBottom = `${this.columnPaddingBottom}px`;
         const visibleStart = this.visibleStartMinute || 0;
@@ -2276,6 +2270,26 @@ class CalendarWeekCard extends HTMLElement {
 
         this.allDayBandHeight = 0;
         this.updateTimeMetrics();
+        const paddedViewportHeight = this.timeViewportHeight + this.columnPaddingTop + this.columnPaddingBottom;
+        if (this.weekBody) {
+            this.weekBody.style.minHeight = `${paddedViewportHeight}px`;
+        }
+        if (this.grid) {
+            this.grid.style.minHeight = `${paddedViewportHeight}px`;
+        }
+        this.dayColumns?.forEach(column => {
+            const timedViewport = column.querySelector(".timed-viewport");
+            const timedEvents = column.querySelector(".timed-events");
+            if (timedViewport) {
+                timedViewport.style.minHeight = `${paddedViewportHeight}px`;
+                timedViewport.style.height = `${paddedViewportHeight}px`;
+                timedViewport.style.paddingTop = `${this.columnPaddingTop}px`;
+                timedViewport.style.paddingBottom = `${this.columnPaddingBottom}px`;
+            }
+            if (timedEvents) {
+                timedEvents.style.minHeight = `${paddedViewportHeight}px`;
+            }
+        });
 
         const highlightEnabled = this.config.highlight_today !== false;
         const highlightEdgeColor = this.getHexColor(this.config.today_highlight_color || "#4D96FF");
@@ -2470,7 +2484,12 @@ class CalendarWeekCard extends HTMLElement {
     }
 
     updateTimeMetrics() {
-        const fallbackViewport = Math.max(this.clientHeight || 0, this.grid?.clientHeight || 0, 480);
+        const totalMinutes = 24 * 60;
+        const rawVisibleDuration = Math.max(
+            (this.visibleEndMinute || totalMinutes) - (this.visibleStartMinute || 0),
+            1
+        );
+        const fallbackViewport = Math.max(this.clientHeight || 0, this.grid?.clientHeight || 0, rawVisibleDuration, 480);
         const firstViewport = this.dayColumns?.[0]?.querySelector(".timed-viewport");
         let viewportHeight = firstViewport?.clientHeight || firstViewport?.offsetHeight || 0;
 
@@ -2494,9 +2513,9 @@ class CalendarWeekCard extends HTMLElement {
             viewportHeight = fallbackViewport;
         }
 
+        viewportHeight = Math.max(viewportHeight, rawVisibleDuration);
         this.timeViewportHeight = viewportHeight;
         const effectiveHeight = Math.max(viewportHeight, 24);
-        const totalMinutes = 24 * 60;
         const visibleStart = Math.max(0, Math.min(Number(this.visibleStartMinute) || 0, totalMinutes - 1));
         const visibleEnd = Math.max(visibleStart + 1, Math.min(Number(this.visibleEndMinute) || totalMinutes, totalMinutes));
         const visibleDuration = Math.max(visibleEnd - visibleStart, 1);
@@ -2504,6 +2523,8 @@ class CalendarWeekCard extends HTMLElement {
         this.visibleEndMinute = visibleEnd;
         this.pixelsPerMinute = effectiveHeight / visibleDuration;
         this.timeAxisOffset = this.columnPaddingTop - visibleStart * this.pixelsPerMinute;
+        const paddedViewportHeight = viewportHeight + this.columnPaddingTop + this.columnPaddingBottom;
+        this.style.setProperty("--cwc-viewport-height", `${paddedViewportHeight}px`);
     }
 
     colorWithAlpha(color, alpha = 1) {
@@ -3487,7 +3508,21 @@ class CalendarWeekCard extends HTMLElement {
     }
 
     getCardSize() {
-        return 20;
+        const header = this.shadowRoot?.querySelector(".header-bar");
+        const body = this.shadowRoot?.querySelector(".week-body");
+        const inlineEmpty = this.shadowRoot?.querySelector(".no-calendars-inline");
+        const headerHeight = header?.scrollHeight || header?.clientHeight || 0;
+        const bodyHeight = body?.scrollHeight || body?.clientHeight || 0;
+        const emptyHeight = inlineEmpty && !inlineEmpty.hidden ? (inlineEmpty.scrollHeight || inlineEmpty.clientHeight || 0) : 0;
+        const measured = headerHeight + Math.max(bodyHeight, emptyHeight);
+        if (measured > 0) {
+            return Math.ceil(measured / 50);
+        }
+
+        const totalMinutes = 24 * 60;
+        const visibleDuration = Math.max((this.visibleEndMinute || totalMinutes) - (this.visibleStartMinute || 0), 1);
+        const estimatedHeight = Math.max(this.timeViewportHeight || visibleDuration, 480);
+        return Math.ceil(estimatedHeight / 50);
     }
 
     static getStubConfig(hass) {

--- a/dist/calendar-week-card.js
+++ b/dist/calendar-week-card.js
@@ -2492,6 +2492,11 @@ class CalendarWeekCard extends HTMLElement {
         const fallbackViewport = Math.max(this.clientHeight || 0, this.grid?.clientHeight || 0, rawVisibleDuration, 480);
         const firstViewport = this.dayColumns?.[0]?.querySelector(".timed-viewport");
         let viewportHeight = firstViewport?.clientHeight || firstViewport?.offsetHeight || 0;
+        const headerHeight = this.shadowRoot?.querySelector(".header-bar")?.getBoundingClientRect?.()?.height ||
+            this.shadowRoot?.querySelector(".header-bar")?.offsetHeight || 0;
+        const root = typeof document !== "undefined" ? document.getElementById("root") : null;
+        const rootRect = root?.getBoundingClientRect?.();
+        const maxViewportHeight = rootRect?.height || root?.clientHeight || root?.offsetHeight || null;
 
         if (!viewportHeight && this.grid) {
             const rect = this.grid.getBoundingClientRect();
@@ -2514,6 +2519,12 @@ class CalendarWeekCard extends HTMLElement {
         }
 
         viewportHeight = Math.max(viewportHeight, rawVisibleDuration);
+        if (maxViewportHeight && maxViewportHeight > 0) {
+            const availableHeight = Math.max(maxViewportHeight - headerHeight, 0);
+            if (availableHeight > 0) {
+                viewportHeight = Math.min(viewportHeight, availableHeight);
+            }
+        }
         this.timeViewportHeight = viewportHeight;
         const effectiveHeight = Math.max(viewportHeight, 24);
         const visibleStart = Math.max(0, Math.min(Number(this.visibleStartMinute) || 0, totalMinutes - 1));

--- a/src/calendar-week-card.js
+++ b/src/calendar-week-card.js
@@ -1965,6 +1965,11 @@ export class CalendarWeekCard extends HTMLElement {
         const fallbackViewport = Math.max(this.clientHeight || 0, this.grid?.clientHeight || 0, rawVisibleDuration, 480);
         const firstViewport = this.dayColumns?.[0]?.querySelector(".timed-viewport");
         let viewportHeight = firstViewport?.clientHeight || firstViewport?.offsetHeight || 0;
+        const headerHeight = this.shadowRoot?.querySelector(".header-bar")?.getBoundingClientRect?.()?.height ||
+            this.shadowRoot?.querySelector(".header-bar")?.offsetHeight || 0;
+        const root = typeof document !== "undefined" ? document.getElementById("root") : null;
+        const rootRect = root?.getBoundingClientRect?.();
+        const maxViewportHeight = rootRect?.height || root?.clientHeight || root?.offsetHeight || null;
 
         if (!viewportHeight && this.grid) {
             const rect = this.grid.getBoundingClientRect();
@@ -1987,6 +1992,12 @@ export class CalendarWeekCard extends HTMLElement {
         }
 
         viewportHeight = Math.max(viewportHeight, rawVisibleDuration);
+        if (maxViewportHeight && maxViewportHeight > 0) {
+            const availableHeight = Math.max(maxViewportHeight - headerHeight, 0);
+            if (availableHeight > 0) {
+                viewportHeight = Math.min(viewportHeight, availableHeight);
+            }
+        }
         this.timeViewportHeight = viewportHeight;
         const effectiveHeight = Math.max(viewportHeight, 24);
         const visibleStart = Math.max(0, Math.min(Number(this.visibleStartMinute) || 0, totalMinutes - 1));

--- a/src/calendar-week-card.js
+++ b/src/calendar-week-card.js
@@ -1993,7 +1993,7 @@ export class CalendarWeekCard extends HTMLElement {
 
         viewportHeight = Math.max(viewportHeight, rawVisibleDuration);
         if (maxViewportHeight && maxViewportHeight > 0) {
-            const availableHeight = Math.max(maxViewportHeight - headerHeight, 0);
+            const availableHeight = Math.max(maxViewportHeight - headerHeight - this.columnPaddingTop - this.columnPaddingBottom, 0);
             if (availableHeight > 0) {
                 viewportHeight = Math.min(viewportHeight, availableHeight);
             }

--- a/src/calendar-week-card.js
+++ b/src/calendar-week-card.js
@@ -891,6 +891,15 @@ export class CalendarWeekCard extends HTMLElement {
                 --cwc-dialog-divider: rgba(255, 255, 255, 0.12);
                 --cwc-today-glow: rgba(77, 150, 255, 0.35);
             }
+            .card-root {
+                position: relative;
+                display: flex;
+                flex-direction: column;
+                width: 100%;
+                height: 100%;
+                max-height: 100%;
+                box-sizing: border-box;
+            }
             .header-bar {
                 display: flex;
                 align-items: center;
@@ -960,6 +969,7 @@ export class CalendarWeekCard extends HTMLElement {
             .week-body {
                 display: flex;
                 width: 100%;
+                flex: 1 1 auto;
                 background: var(--cwc-week-bg);
                 min-height: var(--cwc-viewport-height);
                 gap: 0;
@@ -1250,27 +1260,30 @@ export class CalendarWeekCard extends HTMLElement {
             }
         </style>
 
-        <div class="header-bar">
-          <div class="nav-buttons">
-            <button class="prev-week">◀</button>
-            <button class="today"></button>
-            <button class="next-week">▶</button>
-          </div>
-          <h3 class="title-line"></h3>
-          <span class="settings-icon">⚙️</span>
-        </div>
-
-        <div class="week-header"></div>
-
-        <div class="week-body">
-            <div class="time-bar"></div>
-            <div class="week-grid">
-                ${[...Array(7)].map(() => `<div class="day-column"></div>`).join("")}
+        <div class="card-root">
+            <div class="header-bar">
+              <div class="nav-buttons">
+                <button class="prev-week">◀</button>
+                <button class="today"></button>
+                <button class="next-week">▶</button>
+              </div>
+              <h3 class="title-line"></h3>
+              <span class="settings-icon">⚙️</span>
             </div>
+
+            <div class="week-header"></div>
+
+            <div class="week-body">
+                <div class="time-bar"></div>
+                <div class="week-grid">
+                    ${[...Array(7)].map(() => `<div class="day-column"></div>`).join("")}
+                </div>
+            </div>
+            <div class="no-calendars-inline" hidden></div>
         </div>
-        <div class="no-calendars-inline" hidden></div>
         `;
 
+        this.cardRoot = this.shadowRoot.querySelector(".card-root");
         this.grid = this.shadowRoot.querySelector(".week-grid");
         this.timeBar = this.shadowRoot.querySelector(".time-bar");
         this.header = this.shadowRoot.querySelector(".week-header");
@@ -1969,7 +1982,10 @@ export class CalendarWeekCard extends HTMLElement {
             this.shadowRoot?.querySelector(".header-bar")?.offsetHeight || 0;
         const root = typeof document !== "undefined" ? document.getElementById("root") : null;
         const rootRect = root?.getBoundingClientRect?.();
-        const maxViewportHeight = rootRect?.height || root?.clientHeight || root?.offsetHeight || null;
+        const rootHeight = rootRect?.height || root?.clientHeight || root?.offsetHeight || null;
+        const containerHeight = this.cardRoot?.getBoundingClientRect?.()?.height || this.cardRoot?.clientHeight ||
+            this.cardRoot?.offsetHeight || null;
+        const maxViewportHeight = rootHeight || containerHeight || null;
 
         if (!viewportHeight && this.grid) {
             const rect = this.grid.getBoundingClientRect();
@@ -1996,6 +2012,15 @@ export class CalendarWeekCard extends HTMLElement {
             const availableHeight = Math.max(maxViewportHeight - headerHeight - this.columnPaddingTop - this.columnPaddingBottom, 0);
             if (availableHeight > 0) {
                 viewportHeight = Math.min(viewportHeight, availableHeight);
+            }
+        }
+        if (this.cardRoot) {
+            if (maxViewportHeight && maxViewportHeight > 0) {
+                this.cardRoot.style.height = `${maxViewportHeight}px`;
+                this.cardRoot.style.maxHeight = `${maxViewportHeight}px`;
+            } else {
+                this.cardRoot.style.removeProperty("height");
+                this.cardRoot.style.removeProperty("max-height");
             }
         }
         this.timeViewportHeight = viewportHeight;


### PR DESCRIPTION
## Summary
- allow the card host and layout containers to size based on content instead of fixed 100% heights
- compute and apply a reusable viewport height so the time grid and bar render with intrinsic dimensions
- improve Home Assistant layout estimation with a measured getCardSize fallback

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694047a48b348328a1fcec0d2e42c59a)